### PR TITLE
feat: animate sequential metrics on dial

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Скорость подключения</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="no-js">
+    <main class="dashboard">
+      <div class="dial">
+        <svg class="dial__frame" viewBox="0 0 900 360" aria-hidden="true">
+          <defs>
+            <linearGradient id="dial-outline-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#ff4d6c" />
+              <stop offset="42%" stop-color="#ff0032" />
+              <stop offset="100%" stop-color="#ff4d6c" />
+            </linearGradient>
+            <linearGradient id="dial-inner-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stop-color="rgba(255, 0, 50, 0.45)" />
+              <stop offset="35%" stop-color="rgba(255, 0, 50, 0.3)" />
+              <stop offset="100%" stop-color="rgba(255, 0, 50, 0.05)" />
+            </linearGradient>
+            <pattern id="dial-grid" patternUnits="userSpaceOnUse" width="44" height="44">
+              <rect class="dial__grid-bar dial__grid-bar--major" x="0" y="0" width="3" height="44"></rect>
+              <rect class="dial__grid-bar dial__grid-bar--minor" x="10" y="0" width="2" height="44"></rect>
+              <rect class="dial__grid-bar dial__grid-bar--major" x="22" y="0" width="3" height="44"></rect>
+              <rect class="dial__grid-bar dial__grid-bar--minor" x="32" y="0" width="2" height="44"></rect>
+            </pattern>
+            <mask id="dial-ring-mask" maskUnits="userSpaceOnUse">
+              <rect x="0" y="0" width="900" height="360" fill="black"></rect>
+              <rect x="42" y="50" width="816" height="260" rx="88" ry="88" fill="white"></rect>
+              <rect x="74" y="82" width="752" height="196" rx="62" ry="62" fill="black"></rect>
+            </mask>
+          </defs>
+          <g class="dial__progress">
+            <rect
+              class="dial__progress-track"
+              x="24"
+              y="32"
+              width="852"
+              height="296"
+              rx="110"
+              ry="110"
+              pathLength="100"
+            ></rect>
+            <rect
+              class="dial__progress-fill"
+              x="24"
+              y="32"
+              width="852"
+              height="296"
+              rx="110"
+              ry="110"
+              pathLength="100"
+            ></rect>
+          </g>
+          <g class="dial__accent">
+            <rect class="dial__mesh" x="0" y="0" width="900" height="360" mask="url(#dial-ring-mask)"></rect>
+            <rect
+              class="dial__pulse"
+              x="48"
+              y="56"
+              width="804"
+              height="248"
+              rx="76"
+              ry="76"
+              pathLength="100"
+            ></rect>
+            <rect
+              class="dial__outline"
+              x="42"
+              y="50"
+              width="816"
+              height="260"
+              rx="88"
+              ry="88"
+              pathLength="100"
+            ></rect>
+            <rect
+              class="dial__inner"
+              x="66"
+              y="74"
+              width="768"
+              height="212"
+              rx="64"
+              ry="64"
+              pathLength="100"
+            ></rect>
+            <g class="dial__corner-sparks">
+              <path class="dial__corner" d="M96 104h74"></path>
+              <path class="dial__corner" d="M96 104v74"></path>
+              <path class="dial__corner" d="M804 104h-74"></path>
+              <path class="dial__corner" d="M804 104v74"></path>
+              <path class="dial__corner" d="M96 256h74"></path>
+              <path class="dial__corner" d="M96 256v-74"></path>
+              <path class="dial__corner" d="M804 256h-74"></path>
+              <path class="dial__corner" d="M804 256v-74"></path>
+            </g>
+          </g>
+        </svg>
+        <div class="dial__gear-indicator" aria-hidden="true">
+          <span class="dial__gear-label">Передача</span>
+          <span class="dial__gear-value">—</span>
+        </div>
+        <div class="metrics">
+          <div class="metric" data-gear="I" data-value="27.18" data-decimals="2" data-duration="1400">
+            <div class="metric__badge" aria-hidden="true">I</div>
+            <div class="metric__title">
+              Входящая
+              <span class="metric__hint" aria-hidden="true">i</span>
+            </div>
+            <div class="metric__value">
+              <span class="metric__value-number">0</span>
+            </div>
+            <div class="metric__unit">Мбит/с</div>
+          </div>
+          <div class="metric" data-gear="II" data-value="30.28" data-decimals="2" data-duration="1200">
+            <div class="metric__badge" aria-hidden="true">II</div>
+            <div class="metric__title">
+              Исходящая
+              <span class="metric__hint" aria-hidden="true">i</span>
+            </div>
+            <div class="metric__value">
+              <span class="metric__value-number">0</span>
+            </div>
+            <div class="metric__unit">Мбит/с</div>
+          </div>
+          <div class="metric" data-gear="III" data-value="32" data-decimals="0" data-duration="1500">
+            <div class="metric__badge" aria-hidden="true">III</div>
+            <div class="metric__title">
+              Задержка
+              <span class="metric__hint" aria-hidden="true">i</span>
+            </div>
+            <div class="metric__value">
+              <span class="metric__value-number">0</span>
+            </div>
+            <div class="metric__unit">мс</div>
+          </div>
+        </div>
+      </div>
+    </main>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const body = document.body;
+        body.classList.remove('no-js');
+        const metrics = Array.from(document.querySelectorAll('.metric'));
+        const gearValue = document.querySelector('.dial__gear-value');
+        if (gearValue) {
+          gearValue.textContent = '—';
+        }
+        const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const bootDelay = reduceMotion ? 0 : 240;
+        const betweenShift = reduceMotion ? 0 : 260;
+        const coolDown = reduceMotion ? 0 : 320;
+        if (!metrics.length) {
+          body.classList.add('is-ready');
+          return;
+        }
+
+        const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+        const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+
+        const animateValue = (element, target, decimals, duration) => {
+          return new Promise((resolve) => {
+            const effectiveDuration = reduceMotion ? 0 : duration;
+            const start = performance.now();
+            const startValue = 0;
+
+            const format = (value) => {
+              if (decimals > 0) {
+                return value.toFixed(decimals);
+              }
+              return Math.round(value).toString();
+            };
+
+            if (effectiveDuration === 0) {
+              element.textContent = format(target);
+              resolve();
+              return;
+            }
+
+            const update = (now) => {
+              const progress = Math.min((now - start) / effectiveDuration, 1);
+              const eased = easeOutCubic(progress);
+              const current = startValue + (target - startValue) * eased;
+              element.textContent = format(current);
+
+              if (progress < 1) {
+                requestAnimationFrame(update);
+              } else {
+                element.textContent = format(target);
+                resolve();
+              }
+            };
+
+            requestAnimationFrame(update);
+          });
+        };
+
+        const startSequence = async () => {
+          body.classList.add('is-ready');
+          await wait(bootDelay);
+
+          for (const metric of metrics) {
+            const valueEl = metric.querySelector('.metric__value-number');
+            const target = Number(metric.dataset.value);
+            const decimals = Number(metric.dataset.decimals || 0);
+            const duration = Number(metric.dataset.duration || 1200);
+            const gear = metric.dataset.gear || '';
+
+            body.dataset.gear = gear;
+            if (gearValue) {
+              gearValue.textContent = gear || '—';
+            }
+            metric.classList.add('metric--active');
+            await animateValue(valueEl, target, decimals, duration);
+            metric.classList.remove('metric--active');
+            metric.classList.add('metric--complete');
+            await wait(betweenShift);
+          }
+
+          await wait(coolDown);
+          body.dataset.gear = '';
+          if (gearValue) {
+            gearValue.textContent = '—';
+          }
+          body.classList.add('is-finished');
+        };
+
+        startSequence();
+      });
+    </script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,477 @@
+:root {
+  color-scheme: dark;
+  font-family: "Manrope", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  --bg: #101214;
+  --panel-bg: #14161a;
+  --panel-shadow: rgba(0, 0, 0, 0.55);
+  --panel-inner: #0d0e10;
+  --panel-stroke: rgba(255, 255, 255, 0.06);
+  --accent: #ff0032;
+  --accent-strong: #ff2247;
+  --accent-soft: rgba(255, 0, 50, 0.55);
+  --accent-glow: rgba(255, 0, 50, 0.32);
+  --text-primary: #ffffff;
+  --text-secondary: #c5c8ce;
+  --text-tertiary: rgba(255, 255, 255, 0.64);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 20% 20%, #181a1f 0%, #08090b 65%, #040506 100%);
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
+  -webkit-font-smoothing: antialiased;
+}
+
+.dashboard {
+  width: min(940px, 94vw);
+}
+
+.dial {
+  position: relative;
+  background: linear-gradient(145deg, var(--panel-bg), #0a0c0f 70%);
+  padding: clamp(36px, 5.5vw, 64px) clamp(28px, 6vw, 72px);
+  border-radius: clamp(50px, 12vw, 170px);
+  box-shadow: 0 40px 90px var(--panel-shadow), inset 0 0 0 1px var(--panel-stroke);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.dial::before {
+  content: "";
+  position: absolute;
+  inset: clamp(18px, 2.6vw, 34px);
+  border-radius: clamp(38px, 10vw, 130px);
+  background: radial-gradient(ellipse at 60% 20%, rgba(255, 0, 50, 0.12), transparent 70%),
+    radial-gradient(ellipse at 30% 80%, rgba(255, 0, 50, 0.1), transparent 70%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(0, 0, 0, 0.5));
+  z-index: 0;
+  opacity: 0.85;
+}
+
+.dial::after {
+  content: "";
+  position: absolute;
+  inset: clamp(32px, 5vw, 56px);
+  border-radius: clamp(30px, 9vw, 120px);
+  background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.04), transparent 65%),
+    radial-gradient(circle at 50% 80%, rgba(255, 0, 50, 0.12), transparent 65%);
+  z-index: 0;
+  opacity: 0.75;
+}
+
+.dial__frame {
+  position: absolute;
+  inset: clamp(12px, 2.2vw, 28px);
+  width: calc(100% - 2 * clamp(12px, 2.2vw, 28px));
+  height: calc(100% - 2 * clamp(12px, 2.2vw, 28px));
+  z-index: 1;
+  fill: none;
+  pointer-events: none;
+}
+
+.dial__gear-indicator {
+  position: absolute;
+  top: clamp(36px, 6vw, 82px);
+  left: 50%;
+  transform: translate(-50%, -10px);
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 20px;
+  border-radius: 999px;
+  background: rgba(10, 11, 14, 0.72);
+  border: 1px solid rgba(255, 0, 50, 0.28);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
+  font-size: 0.78rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+  z-index: 3;
+  opacity: 0;
+  transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
+    background 0.3s ease, border-color 0.3s ease;
+}
+
+.dial__gear-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.42em;
+  color: rgba(255, 255, 255, 0.38);
+}
+
+.dial__gear-value {
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.65);
+  min-width: 2ch;
+  text-align: center;
+}
+
+body.is-ready .dial__gear-indicator {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+body[data-gear]:not([data-gear=""]) .dial__gear-indicator {
+  background: rgba(255, 0, 50, 0.18);
+  border-color: rgba(255, 0, 50, 0.45);
+  box-shadow: 0 18px 44px rgba(255, 0, 50, 0.24);
+  color: rgba(255, 255, 255, 0.72);
+}
+
+body[data-gear]:not([data-gear=""]) .dial__gear-value {
+  color: #ffffff;
+}
+
+body.is-finished .dial__gear-indicator {
+  opacity: 0;
+  transform: translate(-50%, -12px);
+}
+
+.dial__accent {
+  filter: drop-shadow(0 0 14px rgba(255, 0, 50, 0.45)) drop-shadow(0 0 44px rgba(255, 0, 50, 0.35));
+}
+
+.dial__mesh {
+  fill: url(#dial-grid);
+  mix-blend-mode: screen;
+  opacity: 0.82;
+}
+
+.dial__grid-bar {
+  fill: rgba(255, 0, 50, 0.22);
+}
+
+.dial__grid-bar--major {
+  opacity: 0.85;
+}
+
+.dial__grid-bar--minor {
+  opacity: 0.55;
+}
+
+.dial__pulse {
+  fill: none;
+  stroke: rgba(255, 0, 50, 0.55);
+  stroke-width: 3;
+  stroke-dasharray: 2.5 14;
+  stroke-linecap: round;
+  stroke-dashoffset: 6;
+  animation: dial-pulse 2.4s linear infinite;
+}
+
+.dial__outline {
+  fill: none;
+  stroke: url(#dial-outline-gradient);
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.95;
+}
+
+.dial__inner {
+  fill: none;
+  stroke: url(#dial-inner-gradient);
+  stroke-width: 2;
+  opacity: 0.8;
+  stroke-dasharray: 14 10;
+  stroke-linecap: round;
+}
+
+.dial__corner-sparks {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.dial__corner {
+  stroke: rgba(255, 0, 50, 0.55);
+  stroke-width: 4;
+  stroke-dasharray: 18 22;
+  stroke-dashoffset: 14;
+  opacity: 0.75;
+  animation: dial-corner 3.2s ease-in-out infinite;
+}
+
+.dial__progress-track,
+.dial__progress-fill {
+  fill: none;
+  stroke-width: 6;
+  stroke-linecap: round;
+}
+
+.dial__progress-track {
+  stroke: rgba(255, 0, 50, 0.18);
+}
+
+.dial__progress-fill {
+  stroke: rgba(255, 0, 50, 0.65);
+  stroke-dasharray: 100;
+  stroke-dashoffset: 100;
+  opacity: 0;
+  filter: drop-shadow(0 0 20px var(--accent-glow));
+}
+
+body.is-ready .dial__progress-fill {
+  opacity: 1;
+  animation: dial-progress 3.4s cubic-bezier(0.21, 0.85, 0.32, 1) forwards;
+}
+
+body.is-finished .dial__progress-fill {
+  stroke: var(--accent);
+}
+
+.metrics {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(18px, 4vw, 46px);
+  padding: clamp(48px, 7vw, 72px) clamp(30px, 6vw, 68px) clamp(36px, 6vw, 60px);
+}
+
+.metrics::before {
+  content: "";
+  position: absolute;
+  inset: clamp(24px, 4vw, 40px) clamp(12px, 3vw, 30px);
+  border-radius: clamp(26px, 6vw, 60px);
+  background: linear-gradient(145deg, rgba(255, 0, 50, 0.12), rgba(10, 11, 14, 0.8));
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  filter: blur(0.5px);
+  opacity: 0.6;
+  z-index: -1;
+}
+
+.metric {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: clamp(10px, 2vw, 18px);
+  padding: clamp(20px, 3vw, 28px) clamp(16px, 3vw, 24px) clamp(28px, 4vw, 34px);
+  border-radius: clamp(24px, 5vw, 42px);
+  background: linear-gradient(160deg, rgba(20, 22, 26, 0.85), rgba(7, 8, 10, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  opacity: 0.25;
+  transform: translateY(24px) scale(0.96);
+  transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
+    filter 0.6s ease;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric::before {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: inherit;
+  background: radial-gradient(circle at 50% 0%, rgba(255, 0, 50, 0.16), transparent 65%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+}
+
+.metric__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  background: rgba(255, 0, 50, 0.18);
+  border: 1px solid rgba(255, 0, 50, 0.36);
+  color: rgba(255, 255, 255, 0.78);
+  transition: transform 0.5s ease, background 0.4s ease, border-color 0.4s ease;
+}
+
+.metric__title {
+  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  letter-spacing: 0.03em;
+}
+
+.metric__hint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.metric__value {
+  font-size: clamp(2.6rem, 6vw, 3.8rem);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--text-primary);
+  text-shadow: 0 0 18px rgba(255, 0, 50, 0.35);
+  transition: color 0.45s ease;
+}
+
+.metric__value-number {
+  display: inline-block;
+  min-width: 5ch;
+  text-align: center;
+}
+
+.metric__unit {
+  font-size: clamp(0.95rem, 1.4vw, 1.1rem);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.metric--active {
+  opacity: 1;
+  transform: translateY(0) scale(1.02);
+  filter: drop-shadow(0 20px 40px rgba(255, 0, 50, 0.38));
+}
+
+.metric--active::before {
+  opacity: 1;
+}
+
+.metric--active .metric__badge {
+  transform: translateY(-4px) scale(1.08);
+  background: rgba(255, 0, 50, 0.32);
+  border-color: rgba(255, 0, 50, 0.65);
+}
+
+.metric--active .metric__title {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.metric--complete {
+  opacity: 0.92;
+  transform: translateY(0) scale(1);
+  filter: drop-shadow(0 16px 32px rgba(0, 0, 0, 0.35));
+}
+
+.metric--complete .metric__value {
+  color: #ffffff;
+}
+
+.metric--complete .metric__badge {
+  background: rgba(255, 0, 50, 0.24);
+  border-color: rgba(255, 0, 50, 0.45);
+}
+
+body.no-js .metric,
+body.no-js .metric::before,
+body.no-js .metric__badge,
+body.no-js .dial__progress-fill,
+body.no-js .dial__corner,
+body.no-js .dial__pulse {
+  animation: none;
+  transition: none;
+}
+
+body.no-js .metric {
+  opacity: 1;
+  transform: none;
+}
+
+body.no-js .dial__progress-fill {
+  opacity: 1;
+  stroke-dashoffset: 0;
+}
+
+body.no-js .dial__gear-indicator {
+  display: none;
+}
+
+@media (max-width: 840px) {
+  .metrics {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    padding: clamp(40px, 6vw, 64px) clamp(18px, 5vw, 44px) clamp(28px, 6vw, 54px);
+  }
+
+  .metrics::before {
+    inset: clamp(18px, 4vw, 34px) clamp(12px, 3vw, 28px);
+  }
+}
+
+@media (max-width: 580px) {
+  .metrics {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+
+  .metric {
+    padding: clamp(24px, 6vw, 34px);
+  }
+}
+
+@keyframes dial-pulse {
+  from {
+    stroke-dashoffset: 6;
+  }
+  to {
+    stroke-dashoffset: -20;
+  }
+}
+
+@keyframes dial-corner {
+  0% {
+    stroke-dashoffset: 14;
+    opacity: 0.35;
+  }
+  45% {
+    opacity: 0.85;
+  }
+  100% {
+    stroke-dashoffset: -26;
+    opacity: 0.45;
+  }
+}
+
+@keyframes dial-progress {
+  0% {
+    stroke-dashoffset: 100;
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+  }
+  38% {
+    stroke-dashoffset: 68;
+  }
+  68% {
+    stroke-dashoffset: 28;
+  }
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  body.is-ready .dial__progress-fill {
+    stroke-dashoffset: 0;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the dial frame with a patterned rectangular accent, corner sparks, and an outer progress rail that fills like a speed build
- remove the static 0/100/1000 labels and add a floating gear indicator above the dial
- orchestrate sequential metric animations with JS so each stat counts up in turn with gear-style shifts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6b4a4c008321b442c94c8deab004