### PR TITLE
feat: animate metrics with gear sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Скорость подключения</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <script src="script.js" defer></script>
+  </head>
+  <body class="no-js">
+    <main class="dashboard">
+      <div class="dial">
+        <svg class="dial__frame" viewBox="0 0 900 360" aria-hidden="true">
+          <defs>
+            <linearGradient id="dial-accent-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#ff4166" />
+              <stop offset="46%" stop-color="#ff0032" />
+              <stop offset="100%" stop-color="#ff5c7a" />
+            </linearGradient>
+            <linearGradient id="dial-outline-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stop-color="rgba(255, 0, 50, 0.72)" />
+              <stop offset="100%" stop-color="rgba(255, 0, 50, 0.18)" />
+            </linearGradient>
+            <pattern id="dial-stripes" patternUnits="userSpaceOnUse" width="42" height="320">
+              <rect x="0" y="0" width="6" height="320" fill="rgba(255, 255, 255, 0.16)" />
+              <rect x="9" y="0" width="10" height="320" fill="rgba(255, 0, 50, 0.85)" />
+              <rect x="24" y="0" width="4" height="320" fill="rgba(255, 119, 137, 0.7)" />
+              <rect x="32" y="0" width="6" height="320" fill="rgba(255, 0, 50, 0.42)" />
+            </pattern>
+            <mask id="dial-stripe-mask" maskUnits="userSpaceOnUse">
+              <rect x="0" y="0" width="900" height="360" fill="black" />
+              <rect x="42" y="48" width="816" height="264" rx="76" ry="76" fill="white" />
+              <rect x="78" y="84" width="744" height="200" rx="48" ry="48" fill="black" />
+            </mask>
+          </defs>
+          <g class="dial__accent">
+            <rect
+              class="dial__rim"
+              x="42"
+              y="48"
+              width="816"
+              height="264"
+              rx="76"
+              ry="76"
+            ></rect>
+            <rect
+              class="dial__inner"
+              x="66"
+              y="72"
+              width="768"
+              height="216"
+              rx="58"
+              ry="58"
+            ></rect>
+            <rect class="dial__stripes" x="0" y="0" width="900" height="360" mask="url(#dial-stripe-mask)"></rect>
+            <rect
+              class="dial__segments"
+              x="42"
+              y="48"
+              width="816"
+              height="264"
+              rx="76"
+              ry="76"
+              pathLength="100"
+            ></rect>
+          </g>
+          <rect
+            class="dial__speed-indicator"
+            x="24"
+            y="30"
+            width="852"
+            height="300"
+            rx="94"
+            ry="94"
+            pathLength="100"
+          ></rect>
+        </svg>
+        <div class="metrics">
+          <div class="metric" data-progress="0.34">
+            <div class="metric__stage" aria-hidden="true">I</div>
+            <div class="metric__title">
+              Входящая
+              <span class="metric__hint" aria-hidden="true">i</span>
+            </div>
+            <div class="metric__value" data-value="27.18" data-precision="2">27.18</div>
+            <div class="metric__unit">Мбит/с</div>
+          </div>
+          <div class="metric" data-progress="0.68">
+            <div class="metric__stage" aria-hidden="true">II</div>
+            <div class="metric__title">
+              Исходящая
+              <span class="metric__hint" aria-hidden="true">i</span>
+            </div>
+            <div class="metric__value" data-value="30.28" data-precision="2">30.28</div>
+            <div class="metric__unit">Мбит/с</div>
+          </div>
+          <div class="metric" data-progress="0.94">
+            <div class="metric__stage" aria-hidden="true">III</div>
+            <div class="metric__title">
+              Задержка
+              <span class="metric__hint" aria-hidden="true">i</span>
+            </div>
+            <div class="metric__value" data-value="32" data-precision="0">32</div>
+            <div class="metric__unit">мс</div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,130 @@
+(() => {
+  "use strict";
+
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+  const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+
+  const formatValue = (value, precision) => {
+    const factor = Math.pow(10, precision);
+    return (Math.round(value * factor) / factor).toFixed(precision);
+  };
+
+  const updateIndicator = (indicator, indicatorLength, progressStep) => {
+    if (!indicator) {
+      return;
+    }
+
+    indicator.style.opacity = 1;
+
+    if (!indicatorLength) {
+      return;
+    }
+
+    const normalized = clamp(Number(progressStep) || 0, 0, 1);
+    const dashOffset = indicatorLength * (1 - normalized);
+
+    requestAnimationFrame(() => {
+      indicator.style.strokeDashoffset = dashOffset;
+    });
+  };
+
+  const accelerateMetric = (metric, indicator, indicatorLength, index, total) => {
+    return new Promise((resolve) => {
+      const valueElement = metric.querySelector(".metric__value");
+      if (!valueElement) {
+        resolve();
+        return;
+      }
+
+      const targetValue = parseFloat(valueElement.dataset.value || "0");
+      const precision = parseInt(valueElement.dataset.precision || "0", 10);
+      const duration = 1200;
+      const cooldown = 220;
+
+      metric.classList.add("metric--active");
+      metric.classList.remove("metric--complete");
+
+      const progressStep = metric.dataset.progress || ((index + 1) / total);
+      updateIndicator(indicator, indicatorLength, progressStep);
+
+      const start = performance.now();
+
+      const step = (now) => {
+        const elapsed = now - start;
+        const linear = Math.min(elapsed / duration, 1);
+        const eased = easeOutCubic(linear);
+        const currentValue = targetValue * eased;
+
+        valueElement.textContent = formatValue(currentValue, precision);
+        valueElement.style.setProperty("--metric-progress", eased.toString());
+
+        if (linear < 1) {
+          requestAnimationFrame(step);
+          return;
+        }
+
+        valueElement.textContent = formatValue(targetValue, precision);
+        valueElement.style.setProperty("--metric-progress", "1");
+        metric.classList.remove("metric--active");
+        metric.classList.add("metric--complete");
+        setTimeout(resolve, cooldown);
+      };
+
+      requestAnimationFrame(step);
+    });
+  };
+
+  window.addEventListener("DOMContentLoaded", async () => {
+    if (document.body.classList.contains("no-js")) {
+      document.body.classList.remove("no-js");
+    }
+
+    const metrics = Array.from(document.querySelectorAll(".metric"));
+    if (!metrics.length) {
+      return;
+    }
+
+    const indicator = document.querySelector(".dial__speed-indicator");
+    let indicatorLength = 0;
+
+    if (indicator) {
+      try {
+        indicatorLength = indicator.getTotalLength();
+      } catch (error) {
+        indicatorLength = 0;
+      }
+
+      if (indicatorLength > 0) {
+        indicator.style.strokeDasharray = indicatorLength;
+        indicator.style.strokeDashoffset = indicatorLength;
+      } else {
+        indicator.style.strokeDasharray = "100";
+        indicator.style.strokeDashoffset = "100";
+      }
+    }
+
+    metrics.forEach((metric) => {
+      metric.classList.remove("metric--active", "metric--complete");
+      const valueElement = metric.querySelector(".metric__value");
+      if (!valueElement) {
+        return;
+      }
+      const precision = parseInt(valueElement.dataset.precision || "0", 10);
+      valueElement.textContent = formatValue(0, precision);
+      valueElement.style.setProperty("--metric-progress", "0");
+    });
+
+    await wait(320);
+
+    try {
+      await metrics.reduce((sequence, metric, index) => {
+        return sequence.then(() => accelerateMetric(metric, indicator, indicatorLength, index, metrics.length));
+      }, Promise.resolve());
+    } catch (error) {
+      console.error(error);
+    }
+  });
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,347 @@
+:root {
+  color-scheme: dark;
+  --bg: #101214;
+  --panel-bg: #15171a;
+  --panel-inner: #0f1012;
+  --panel-highlight: rgba(255, 255, 255, 0.04);
+  --accent: #ff0032;
+  --accent-soft: rgba(255, 0, 50, 0.55);
+  --accent-glow: rgba(255, 0, 50, 0.32);
+  --text-primary: #ffffff;
+  --text-secondary: #c5c8ce;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Manrope", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: radial-gradient(circle at 50% 50%, #17181b 0%, #0a0b0c 100%);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-primary);
+  transition: background 0.5s ease;
+}
+
+body.no-js .metric,
+body.no-js .metric__value {
+  opacity: 1;
+  transform: none;
+}
+
+body.no-js .metric::before,
+body.no-js .metric::after,
+body.no-js .dial__speed-indicator {
+  display: none;
+}
+
+.dashboard {
+  width: min(920px, 92vw);
+}
+
+.dial {
+  position: relative;
+  background: linear-gradient(155deg, var(--panel-bg), #0b0c0e 78%);
+  padding: clamp(32px, 5vw, 60px) clamp(24px, 4vw, 48px);
+  border-radius: clamp(48px, 12vw, 160px);
+  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.45), inset 0 0 0 2px rgba(255, 255, 255, 0.03);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.dial::before {
+  content: "";
+  position: absolute;
+  inset: clamp(18px, 2.6vw, 34px);
+  border-radius: clamp(36px, 10vw, 120px);
+  background: radial-gradient(ellipse at top, rgba(255, 0, 50, 0.12), transparent 70%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.45));
+  z-index: 0;
+  pointer-events: none;
+}
+
+.dial::after {
+  content: "";
+  position: absolute;
+  inset: clamp(48px, 8vw, 80px);
+  border-radius: clamp(28px, 8vw, 100px);
+  background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.08), transparent 58%),
+    radial-gradient(circle at 78% 68%, rgba(255, 0, 50, 0.08), transparent 64%);
+  z-index: 0;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.dial__frame {
+  position: absolute;
+  --frame-inset: clamp(10px, 1.6vw, 22px);
+  inset: var(--frame-inset);
+  width: calc(100% - 2 * var(--frame-inset));
+  height: calc(100% - 2 * var(--frame-inset));
+  z-index: 1;
+  fill: none;
+}
+
+.dial__accent {
+  filter: drop-shadow(0 0 14px rgba(255, 0, 50, 0.45))
+    drop-shadow(0 0 30px rgba(255, 0, 50, 0.4));
+}
+
+.dial__rim {
+  fill: none;
+  stroke: url(#dial-accent-gradient);
+  stroke-width: 3.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+  opacity: 0.92;
+}
+
+.dial__inner {
+  fill: none;
+  stroke: url(#dial-outline-gradient);
+  stroke-width: 1.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.dial__stripes {
+  fill: url(#dial-stripes);
+  opacity: 0.88;
+  mix-blend-mode: screen;
+  animation: dialStripes 18s linear infinite;
+  will-change: transform;
+}
+
+.dial__segments {
+  fill: none;
+  stroke: var(--accent-soft);
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+  stroke-dasharray: 1 3;
+  animation: dialSegments 16s linear infinite;
+}
+
+.dial__speed-indicator {
+  fill: none;
+  stroke: url(#dial-accent-gradient);
+  stroke-width: 6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+  stroke-dasharray: 100;
+  stroke-dashoffset: 100;
+  opacity: 0;
+  filter: drop-shadow(0 0 22px rgba(255, 0, 50, 0.4))
+    drop-shadow(0 0 40px rgba(255, 0, 50, 0.24));
+  transition: stroke-dashoffset 1.2s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.8s ease;
+}
+
+.metrics {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  gap: clamp(16px, 4vw, 40px);
+  padding: clamp(40px, 6vw, 64px) clamp(24px, 5vw, 60px);
+}
+
+.metric {
+  flex: 1;
+  position: relative;
+  text-align: center;
+  display: grid;
+  gap: clamp(10px, 1.8vw, 16px);
+  justify-items: center;
+  padding: clamp(14px, 2.4vw, 22px) clamp(10px, 1.8vw, 18px);
+  border-radius: clamp(22px, 6vw, 34px);
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  overflow: hidden;
+  opacity: 0.4;
+  transform: translateY(12px);
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.5s ease, filter 0.5s ease;
+}
+
+.metric::before,
+.metric::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.45s ease, transform 0.45s ease;
+}
+
+.metric::before {
+  background: linear-gradient(120deg, var(--accent-glow), transparent 65%);
+  transform: translateX(-12%);
+}
+
+.metric::after {
+  border: 1px solid rgba(255, 0, 50, 0.3);
+  mix-blend-mode: screen;
+  transform: scale(0.92);
+}
+
+.metric--active,
+.metric--complete {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.metric--active::before {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.metric--active::after {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.metric--active {
+  filter: drop-shadow(0 18px 30px var(--accent-glow));
+}
+
+.metric--complete::before {
+  opacity: 0.6;
+  transform: translateX(-4%);
+}
+
+.metric__stage {
+  font-size: clamp(0.9rem, 1.2vw, 1rem);
+  font-weight: 600;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.45);
+  transition: color 0.4s ease;
+}
+
+.metric--active .metric__stage {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.metric__title {
+  font-size: clamp(1rem, 1.4vw, 1.2rem);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  letter-spacing: 0.02em;
+  transition: color 0.4s ease;
+}
+
+.metric--active .metric__title,
+.metric--complete .metric__title {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.metric__hint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.8rem;
+  font-weight: 600;
+  backdrop-filter: blur(4px);
+}
+
+.metric__value {
+  font-size: clamp(2.8rem, 6vw, 3.6rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.7);
+  text-shadow: 0 0 18px rgba(255, 255, 255, 0.05);
+  position: relative;
+  transition: color 0.4s ease, text-shadow 0.4s ease, transform 0.5s ease;
+  transform: translateY(8px) scale(0.98);
+}
+
+.metric__value::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  background: radial-gradient(
+    circle at 50% 0%,
+    rgba(255, 255, 255, 0.22) 0%,
+    transparent 58%
+  );
+  opacity: calc(var(--metric-progress, 0));
+  pointer-events: none;
+  transition: opacity 0.45s ease;
+}
+
+.metric--active .metric__value {
+  color: var(--accent);
+  text-shadow: 0 0 18px rgba(255, 0, 50, 0.65), 0 0 32px rgba(255, 0, 50, 0.36);
+  transform: translateY(0) scale(1.02);
+}
+
+.metric--complete .metric__value {
+  color: var(--text-primary);
+  text-shadow: 0 0 20px rgba(255, 255, 255, 0.18);
+  transform: translateY(0) scale(1);
+}
+
+.metric__unit {
+  font-size: clamp(0.95rem, 1.4vw, 1.1rem);
+  color: rgba(255, 255, 255, 0.62);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  transition: color 0.4s ease;
+}
+
+.metric--active .metric__unit,
+.metric--complete .metric__unit {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+@keyframes dialStripes {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-42px);
+  }
+}
+
+@keyframes dialSegments {
+  0% {
+    stroke-dashoffset: 0;
+  }
+  100% {
+    stroke-dashoffset: -8;
+  }
+}
+
+@media (max-width: 640px) {
+  .metrics {
+    flex-direction: column;
+    gap: 32px;
+    padding: clamp(40px, 6vw, 64px) clamp(16px, 5vw, 40px);
+  }
+
+  .metric {
+    transform: translateY(18px);
+  }
+
+  .metric__value {
+    font-size: clamp(2.4rem, 10vw, 3rem);
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the dial with layered gradients, animated stripes and a progressive outer indicator ring
- remove static number labels and introduce gear badges for each metric
- add a JavaScript gear-shift sequence that animates metrics and fills the speed indicator on load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6b4a4c008321b442c94c8deab004