### PR TITLE
feat: redesign dial frame with progressive animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Скорость подключения</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="dashboard">
+      <div class="dial">
+        <svg class="dial__indicator" viewBox="0 0 900 360" aria-hidden="true">
+          <defs>
+            <linearGradient
+              id="dial-indicator-gradient"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <stop offset="0%" stop-color="rgba(255, 255, 255, 0.65)" />
+              <stop offset="32%" stop-color="#ff3b62" />
+              <stop offset="72%" stop-color="#ff0032" />
+              <stop offset="100%" stop-color="#ff5a79" />
+            </linearGradient>
+          </defs>
+          <rect
+            class="dial__indicator-track"
+            x="12"
+            y="12"
+            width="876"
+            height="336"
+            rx="140"
+            ry="140"
+            pathLength="100"
+          ></rect>
+          <rect
+            class="dial__indicator-progress"
+            x="12"
+            y="12"
+            width="876"
+            height="336"
+            rx="140"
+            ry="140"
+            pathLength="100"
+          ></rect>
+        </svg>
+        <svg class="dial__frame" viewBox="0 0 900 360" aria-hidden="true">
+          <defs>
+            <linearGradient
+              id="dial-rail-gradient"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <stop offset="0%" stop-color="#ff667f" />
+              <stop offset="35%" stop-color="#ff0032" />
+              <stop offset="70%" stop-color="#ff2952" />
+              <stop offset="100%" stop-color="#ff6f86" />
+            </linearGradient>
+            <pattern
+              id="dial-stripe-pattern"
+              patternUnits="userSpaceOnUse"
+              width="26"
+              height="26"
+            >
+              <rect x="0" y="0" width="4" height="26" fill="rgba(255, 0, 50, 0.52)"></rect>
+              <rect x="11" y="0" width="2" height="26" fill="rgba(255, 255, 255, 0.18)"></rect>
+            </pattern>
+            <mask id="dial-ribbon-mask">
+              <rect x="0" y="0" width="900" height="360" fill="white"></rect>
+              <rect x="72" y="72" width="756" height="216" rx="64" ry="64" fill="black"></rect>
+            </mask>
+            <mask id="dial-stripe-mask">
+              <rect x="36" y="42" width="828" height="276" rx="90" ry="90" fill="white"></rect>
+              <rect x="70" y="74" width="760" height="212" rx="66" ry="66" fill="black"></rect>
+            </mask>
+          </defs>
+          <rect
+            class="dial__frame-ribbon"
+            x="36"
+            y="42"
+            width="828"
+            height="276"
+            rx="90"
+            ry="90"
+            mask="url(#dial-ribbon-mask)"
+          ></rect>
+          <rect
+            class="dial__frame-outline"
+            x="56"
+            y="60"
+            width="788"
+            height="240"
+            rx="74"
+            ry="74"
+            pathLength="100"
+          ></rect>
+          <rect
+            class="dial__frame-outline dial__frame-outline--inner"
+            x="64"
+            y="68"
+            width="772"
+            height="224"
+            rx="66"
+            ry="66"
+            pathLength="100"
+          ></rect>
+          <g class="dial__frame-stripes" mask="url(#dial-stripe-mask)">
+            <rect
+              class="dial__frame-stripe-fill"
+              x="36"
+              y="42"
+              width="828"
+              height="276"
+            ></rect>
+          </g>
+          <g class="dial__frame-markers">
+            <line x1="180" y1="57" x2="720" y2="57"></line>
+            <line x1="180" y1="303" x2="720" y2="303"></line>
+            <line x1="72" y1="128" x2="72" y2="232"></line>
+            <line x1="828" y1="128" x2="828" y2="232"></line>
+          </g>
+        </svg>
+        <div class="metrics">
+          <div class="metric">
+            <div class="metric__title">
+              Входящая
+              <span class="metric__hint" aria-hidden="true">i</span>
+            </div>
+            <div class="metric__value">27.18</div>
+            <div class="metric__unit">Мбит/с</div>
+          </div>
+          <div class="metric">
+            <div class="metric__title">
+              Исходящая
+              <span class="metric__hint" aria-hidden="true">i</span>
+            </div>
+            <div class="metric__value">30.28</div>
+            <div class="metric__unit">Мбит/с</div>
+          </div>
+          <div class="metric">
+            <div class="metric__title">
+              Задержка
+              <span class="metric__hint" aria-hidden="true">i</span>
+            </div>
+            <div class="metric__value">32</div>
+            <div class="metric__unit">мс</div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,388 @@
+:root {
+  color-scheme: dark;
+  --bg: #101214;
+  --panel-bg: #15171a;
+  --panel-inner: #0f1012;
+  --accent: #ff0032;
+  --text-primary: #ffffff;
+  --text-secondary: #c5c8ce;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Manrope", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background: radial-gradient(circle at 50% 50%, #17181b 0%, #0a0b0c 100%);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-primary);
+}
+
+.dashboard {
+  width: min(920px, 92vw);
+}
+
+.dial {
+  position: relative;
+  --frame-inset: clamp(14px, 2.1vw, 28px);
+  --indicator-inset: calc(var(--frame-inset) * 0.45);
+  --glow: rgba(255, 0, 50, 0.42);
+  background: linear-gradient(145deg, var(--panel-bg), #0c0d0f 78%);
+  padding: clamp(32px, 5vw, 60px) clamp(24px, 4vw, 48px);
+  border-radius: clamp(48px, 12vw, 160px);
+  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.45), inset 0 0 0 2px rgba(255, 255, 255, 0.03);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.dial::before {
+  content: "";
+  position: absolute;
+  inset: clamp(18px, 2.4vw, 32px);
+  border-radius: clamp(36px, 10vw, 120px);
+  background:
+    radial-gradient(ellipse at 50% 30%, rgba(255, 0, 50, 0.1), rgba(0, 0, 0, 0) 70%),
+    radial-gradient(ellipse at 50% 120%, rgba(255, 0, 50, 0.12), rgba(0, 0, 0, 0) 68%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(0, 0, 0, 0.46));
+  z-index: 0;
+}
+
+.dial__indicator,
+.dial__frame {
+  position: absolute;
+  pointer-events: none;
+  width: calc(100% - 2 * var(--frame-inset));
+  height: calc(100% - 2 * var(--frame-inset));
+  fill: none;
+}
+
+.dial__indicator {
+  inset: var(--indicator-inset);
+  width: calc(100% - 2 * var(--indicator-inset));
+  height: calc(100% - 2 * var(--indicator-inset));
+  z-index: 1;
+}
+
+.dial__frame {
+  inset: var(--frame-inset);
+  z-index: 2;
+  filter: drop-shadow(0 0 18px var(--glow))
+    drop-shadow(0 0 34px rgba(255, 0, 50, 0.32));
+}
+
+.dial__indicator-track,
+.dial__indicator-progress {
+  fill: none;
+  stroke-width: clamp(6px, 1.3vw, 9px);
+  stroke-linecap: round;
+  stroke-dasharray: 100;
+}
+
+.dial__indicator-track {
+  stroke: rgba(255, 255, 255, 0.08);
+}
+
+.dial__indicator-progress {
+  stroke: url(#dial-indicator-gradient);
+  stroke-dashoffset: 100;
+  filter: drop-shadow(0 0 18px rgba(255, 0, 50, 0.46))
+    drop-shadow(0 0 42px rgba(255, 0, 50, 0.32));
+  animation: indicatorFill 4.4s cubic-bezier(0.3, 0.04, 0.2, 1) forwards;
+}
+
+.dial__frame-ribbon {
+  fill: url(#dial-rail-gradient);
+  opacity: 0.76;
+  mix-blend-mode: screen;
+}
+
+.dial__frame-outline {
+  fill: none;
+  stroke: rgba(255, 0, 50, 0.78);
+  stroke-width: 2.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 3.4 12.4;
+  stroke-dashoffset: 0;
+  animation: outlineSweep 12s linear infinite;
+}
+
+.dial__frame-outline--inner {
+  stroke: rgba(255, 96, 132, 0.72);
+  stroke-width: 1.6;
+  stroke-dasharray: 1.1 7.5;
+  stroke-dashoffset: 8;
+  opacity: 0.58;
+  animation-duration: 16s;
+  animation-direction: reverse;
+}
+
+.dial__frame-stripes {
+  mix-blend-mode: screen;
+}
+
+.dial__frame-stripe-fill {
+  fill: url(#dial-stripe-pattern);
+  opacity: 0.55;
+}
+
+.dial__frame-markers line {
+  stroke: rgba(255, 52, 104, 0.68);
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-dasharray: 16 28;
+  animation: markerPulse 6s ease-in-out infinite;
+}
+
+.dial__frame-markers line:nth-child(odd) {
+  animation-delay: 1.4s;
+}
+
+.metrics {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  justify-content: space-between;
+  gap: clamp(16px, 4vw, 40px);
+  padding: clamp(40px, 6vw, 64px) clamp(24px, 5vw, 60px);
+}
+
+.metric {
+  position: relative;
+  flex: 1;
+  text-align: center;
+  display: grid;
+  gap: clamp(8px, 1.5vw, 14px);
+  justify-items: center;
+  opacity: 0;
+  transform: translateY(42px) scale(0.92);
+  filter: blur(12px);
+  will-change: transform, opacity, filter;
+  --gear-delay: 0s;
+  animation: gearShift 1.45s cubic-bezier(0.25, 0.6, 0.12, 1) forwards;
+  animation-delay: var(--gear-delay);
+}
+
+.metric::after {
+  content: "";
+  position: absolute;
+  inset: 12% 8%;
+  border-radius: clamp(18px, 5vw, 38px);
+  background:
+    radial-gradient(circle at 30% 50%, rgba(255, 255, 255, 0.2), transparent 60%),
+    linear-gradient(100deg, rgba(255, 0, 50, 0.8), rgba(255, 132, 160, 0.2));
+  opacity: 0;
+  transform: scaleX(0.2) translateX(-70%);
+  transform-origin: left center;
+  filter: blur(12px);
+  mix-blend-mode: screen;
+  pointer-events: none;
+  animation: gearFlash 1.05s cubic-bezier(0.42, 0.02, 0.25, 1) forwards;
+  animation-delay: calc(var(--gear-delay) + 0.05s);
+}
+
+.metric:nth-child(1) {
+  --gear-delay: 0.2s;
+}
+
+.metric:nth-child(2) {
+  --gear-delay: 1.05s;
+}
+
+.metric:nth-child(3) {
+  --gear-delay: 1.9s;
+}
+
+.metric__title {
+  font-size: clamp(1rem, 1.4vw, 1.2rem);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  letter-spacing: 0.02em;
+  position: relative;
+  z-index: 1;
+}
+
+.metric__hint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.metric__value {
+  font-size: clamp(2.8rem, 6vw, 3.6rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-primary);
+  position: relative;
+  z-index: 1;
+}
+
+.metric__unit {
+  font-size: clamp(0.95rem, 1.4vw, 1.1rem);
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  position: relative;
+  z-index: 1;
+}
+
+@keyframes indicatorFill {
+  0% {
+    stroke-dashoffset: 100;
+  }
+  20% {
+    stroke-dashoffset: 64;
+  }
+  28% {
+    stroke-dashoffset: 68;
+  }
+  48% {
+    stroke-dashoffset: 36;
+  }
+  58% {
+    stroke-dashoffset: 40;
+  }
+  72% {
+    stroke-dashoffset: 0;
+  }
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes outlineSweep {
+  0% {
+    stroke-dashoffset: 0;
+  }
+  100% {
+    stroke-dashoffset: -200;
+  }
+}
+
+@keyframes markerPulse {
+  0% {
+    opacity: 0.55;
+    stroke-dashoffset: 0;
+  }
+  45% {
+    opacity: 0.85;
+  }
+  100% {
+    opacity: 0.55;
+    stroke-dashoffset: -44;
+  }
+}
+
+@keyframes gearShift {
+  0% {
+    opacity: 0;
+    transform: translateY(46px) scale(0.88);
+    filter: blur(14px);
+  }
+  22% {
+    opacity: 1;
+    transform: translateY(-6px) scale(1.06);
+    filter: blur(0);
+  }
+  36% {
+    transform: translateY(0) scale(1);
+  }
+  50% {
+    transform: translateY(-3px) scale(1.02);
+  }
+  68% {
+    transform: translateY(0) scale(1);
+  }
+  84% {
+    transform: translateY(-1px) scale(1.01);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    filter: blur(0);
+  }
+}
+
+@keyframes gearFlash {
+  0% {
+    opacity: 0;
+    transform: scaleX(0.15) translateX(-80%);
+  }
+  24% {
+    opacity: 0.95;
+    transform: scaleX(1) translateX(0);
+  }
+  46% {
+    opacity: 0.55;
+    transform: scaleX(1.16) translateX(16%);
+  }
+  74% {
+    opacity: 0;
+    transform: scaleX(1.4) translateX(120%);
+  }
+  100% {
+    opacity: 0;
+    transform: scaleX(1.4) translateX(180%);
+  }
+}
+
+@media (max-width: 640px) {
+  .metrics {
+    flex-direction: column;
+    gap: clamp(28px, 8vw, 40px);
+    padding: clamp(40px, 6vw, 64px) clamp(16px, 5vw, 40px);
+  }
+
+  .metric {
+    margin: 0 auto;
+    max-width: 320px;
+  }
+
+  .metric::after {
+    inset: 10% 12%;
+  }
+
+  .metric__value {
+    font-size: clamp(2.4rem, 10vw, 3rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dial__indicator-progress,
+  .dial__frame-outline,
+  .dial__frame-outline--inner,
+  .dial__frame-markers line,
+  .metric,
+  .metric::after {
+    animation: none !important;
+  }
+
+  .dial__indicator-progress {
+    stroke-dashoffset: 0 !important;
+  }
+
+  .metric {
+    opacity: 1 !important;
+    transform: none !important;
+    filter: none !important;
+  }
+
+  .metric::after {
+    opacity: 0 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- wrap the dashboard with a new outer progress ring that charges up on load
- rebuild the red dial frame into layered masks, stripes and marker bars for a cleaner rectangular look
- choreograph the three metrics with staggered "gear shift" animations and remove the numeric labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6b4a4c008321b442c94c8deab004