### PR TITLE
chore: simplify dial layout for cleaner variant

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,33 +15,117 @@
   <body class="no-js">
     <main class="dashboard">
       <div class="dial">
-        <svg class="dial__frame" viewBox="0 0 320 320" aria-hidden="true">
+        <svg class="dial__frame" viewBox="0 0 900 360" aria-hidden="true">
           <defs>
+            <linearGradient id="dial-track-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="rgba(255, 0, 50, 0.28)" />
+              <stop offset="100%" stop-color="rgba(255, 0, 50, 0.14)" />
+            </linearGradient>
             <linearGradient id="dial-progress-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
               <stop offset="0%" stop-color="#ff3355" />
               <stop offset="100%" stop-color="#ff0032" />
             </linearGradient>
+            <linearGradient id="dial-outline-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#ff516d" />
+              <stop offset="50%" stop-color="#ff0032" />
+              <stop offset="100%" stop-color="#ff4d6c" />
+            </linearGradient>
           </defs>
-          <circle class="dial__ring-track" cx="160" cy="160" r="120" pathLength="100"></circle>
-          <circle class="dial__ring-fill" cx="160" cy="160" r="120" pathLength="100"></circle>
-          <circle class="dial__ring-center" cx="160" cy="160" r="88"></circle>
+          <g class="dial__progress">
+            <rect
+              class="dial__progress-track"
+              x="32"
+              y="42"
+              width="836"
+              height="276"
+              rx="102"
+              ry="102"
+              pathLength="100"
+            ></rect>
+            <rect
+              class="dial__progress-fill"
+              x="32"
+              y="42"
+              width="836"
+              height="276"
+              rx="102"
+              ry="102"
+              pathLength="100"
+            ></rect>
+          </g>
+          <g class="dial__accent">
+            <rect
+              class="dial__face"
+              x="58"
+              y="68"
+              width="784"
+              height="224"
+              rx="74"
+              ry="74"
+            ></rect>
+            <rect
+              class="dial__outline"
+              x="46"
+              y="56"
+              width="808"
+              height="248"
+              rx="86"
+              ry="86"
+              pathLength="100"
+            ></rect>
+            <rect
+              class="dial__inner"
+              x="80"
+              y="90"
+              width="740"
+              height="188"
+              rx="60"
+              ry="60"
+              pathLength="100"
+            ></rect>
+          </g>
         </svg>
+        <div class="dial__gear-indicator" aria-hidden="true">
+          <span class="dial__gear-label">Передача</span>
+          <span class="dial__gear-value">—</span>
+        </div>
         <div class="metrics">
-          <div class="metric" data-value="27.18" data-decimals="2" data-duration="1400">
+          <div
+            class="metric"
+            data-gear="I"
+            data-value="27.18"
+            data-decimals="2"
+            data-duration="1400"
+          >
+            <div class="metric__badge" aria-hidden="true">I</div>
             <div class="metric__title">Входящая</div>
             <div class="metric__value">
               <span class="metric__value-number">0</span>
               <span class="metric__unit">Мбит/с</span>
             </div>
           </div>
-          <div class="metric" data-value="30.28" data-decimals="2" data-duration="1200">
+          <div
+            class="metric"
+            data-gear="II"
+            data-value="30.28"
+            data-decimals="2"
+            data-duration="1200"
+          >
+            <div class="metric__badge" aria-hidden="true">II</div>
             <div class="metric__title">Исходящая</div>
             <div class="metric__value">
               <span class="metric__value-number">0</span>
               <span class="metric__unit">Мбит/с</span>
             </div>
           </div>
-          <div class="metric" data-value="32" data-decimals="0" data-duration="1500">
+          <div
+            class="metric"
+            data-gear="III"
+            data-value="32"
+            data-decimals="0"
+            data-duration="1500"
+          >
+            <div class="metric__badge" aria-hidden="true">III</div>
             <div class="metric__title">Задержка</div>
             <div class="metric__value">
               <span class="metric__value-number">0</span>
@@ -56,6 +140,10 @@
         const body = document.body;
         body.classList.remove('no-js');
         const metrics = Array.from(document.querySelectorAll('.metric'));
+        const gearValue = document.querySelector('.dial__gear-value');
+        if (gearValue) {
+          gearValue.textContent = '—';
+        }
         const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         const bootDelay = reduceMotion ? 0 : 240;
         const betweenShift = reduceMotion ? 0 : 260;
@@ -114,6 +202,13 @@
             const target = Number(metric.dataset.value);
             const decimals = Number(metric.dataset.decimals || 0);
             const duration = Number(metric.dataset.duration || 1200);
+            const gear = metric.dataset.gear || '';
+
+            body.dataset.gear = gear;
+            if (gearValue) {
+              gearValue.textContent = gear || '—';
+            }
+
             metric.classList.add('metric--active');
             await animateValue(valueEl, target, decimals, duration);
             metric.classList.remove('metric--active');
@@ -122,6 +217,10 @@
           }
 
           await wait(coolDown);
+          body.dataset.gear = '';
+          if (gearValue) {
+            gearValue.textContent = '—';
+          }
           body.classList.add('is-finished');
         };
 

--- a/index.html
+++ b/index.html
@@ -15,133 +15,38 @@
   <body class="no-js">
     <main class="dashboard">
       <div class="dial">
-        <svg class="dial__frame" viewBox="0 0 900 360" aria-hidden="true">
+        <svg class="dial__frame" viewBox="0 0 320 320" aria-hidden="true">
           <defs>
-            <linearGradient id="dial-outline-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-              <stop offset="0%" stop-color="#ff4d6c" />
-              <stop offset="42%" stop-color="#ff0032" />
-              <stop offset="100%" stop-color="#ff4d6c" />
+            <linearGradient id="dial-progress-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#ff3355" />
+              <stop offset="100%" stop-color="#ff0032" />
             </linearGradient>
-            <linearGradient id="dial-inner-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="0%" stop-color="rgba(255, 0, 50, 0.45)" />
-              <stop offset="35%" stop-color="rgba(255, 0, 50, 0.3)" />
-              <stop offset="100%" stop-color="rgba(255, 0, 50, 0.05)" />
-            </linearGradient>
-            <pattern id="dial-grid" patternUnits="userSpaceOnUse" width="44" height="44">
-              <rect class="dial__grid-bar dial__grid-bar--major" x="0" y="0" width="3" height="44"></rect>
-              <rect class="dial__grid-bar dial__grid-bar--minor" x="10" y="0" width="2" height="44"></rect>
-              <rect class="dial__grid-bar dial__grid-bar--major" x="22" y="0" width="3" height="44"></rect>
-              <rect class="dial__grid-bar dial__grid-bar--minor" x="32" y="0" width="2" height="44"></rect>
-            </pattern>
-            <mask id="dial-ring-mask" maskUnits="userSpaceOnUse">
-              <rect x="0" y="0" width="900" height="360" fill="black"></rect>
-              <rect x="42" y="50" width="816" height="260" rx="88" ry="88" fill="white"></rect>
-              <rect x="74" y="82" width="752" height="196" rx="62" ry="62" fill="black"></rect>
-            </mask>
           </defs>
-          <g class="dial__progress">
-            <rect
-              class="dial__progress-track"
-              x="24"
-              y="32"
-              width="852"
-              height="296"
-              rx="110"
-              ry="110"
-              pathLength="100"
-            ></rect>
-            <rect
-              class="dial__progress-fill"
-              x="24"
-              y="32"
-              width="852"
-              height="296"
-              rx="110"
-              ry="110"
-              pathLength="100"
-            ></rect>
-          </g>
-          <g class="dial__accent">
-            <rect class="dial__mesh" x="0" y="0" width="900" height="360" mask="url(#dial-ring-mask)"></rect>
-            <rect
-              class="dial__pulse"
-              x="48"
-              y="56"
-              width="804"
-              height="248"
-              rx="76"
-              ry="76"
-              pathLength="100"
-            ></rect>
-            <rect
-              class="dial__outline"
-              x="42"
-              y="50"
-              width="816"
-              height="260"
-              rx="88"
-              ry="88"
-              pathLength="100"
-            ></rect>
-            <rect
-              class="dial__inner"
-              x="66"
-              y="74"
-              width="768"
-              height="212"
-              rx="64"
-              ry="64"
-              pathLength="100"
-            ></rect>
-            <g class="dial__corner-sparks">
-              <path class="dial__corner" d="M96 104h74"></path>
-              <path class="dial__corner" d="M96 104v74"></path>
-              <path class="dial__corner" d="M804 104h-74"></path>
-              <path class="dial__corner" d="M804 104v74"></path>
-              <path class="dial__corner" d="M96 256h74"></path>
-              <path class="dial__corner" d="M96 256v-74"></path>
-              <path class="dial__corner" d="M804 256h-74"></path>
-              <path class="dial__corner" d="M804 256v-74"></path>
-            </g>
-          </g>
+          <circle class="dial__ring-track" cx="160" cy="160" r="120" pathLength="100"></circle>
+          <circle class="dial__ring-fill" cx="160" cy="160" r="120" pathLength="100"></circle>
+          <circle class="dial__ring-center" cx="160" cy="160" r="88"></circle>
         </svg>
-        <div class="dial__gear-indicator" aria-hidden="true">
-          <span class="dial__gear-label">Передача</span>
-          <span class="dial__gear-value">—</span>
-        </div>
         <div class="metrics">
-          <div class="metric" data-gear="I" data-value="27.18" data-decimals="2" data-duration="1400">
-            <div class="metric__badge" aria-hidden="true">I</div>
-            <div class="metric__title">
-              Входящая
-              <span class="metric__hint" aria-hidden="true">i</span>
-            </div>
+          <div class="metric" data-value="27.18" data-decimals="2" data-duration="1400">
+            <div class="metric__title">Входящая</div>
             <div class="metric__value">
               <span class="metric__value-number">0</span>
+              <span class="metric__unit">Мбит/с</span>
             </div>
-            <div class="metric__unit">Мбит/с</div>
           </div>
-          <div class="metric" data-gear="II" data-value="30.28" data-decimals="2" data-duration="1200">
-            <div class="metric__badge" aria-hidden="true">II</div>
-            <div class="metric__title">
-              Исходящая
-              <span class="metric__hint" aria-hidden="true">i</span>
-            </div>
+          <div class="metric" data-value="30.28" data-decimals="2" data-duration="1200">
+            <div class="metric__title">Исходящая</div>
             <div class="metric__value">
               <span class="metric__value-number">0</span>
+              <span class="metric__unit">Мбит/с</span>
             </div>
-            <div class="metric__unit">Мбит/с</div>
           </div>
-          <div class="metric" data-gear="III" data-value="32" data-decimals="0" data-duration="1500">
-            <div class="metric__badge" aria-hidden="true">III</div>
-            <div class="metric__title">
-              Задержка
-              <span class="metric__hint" aria-hidden="true">i</span>
-            </div>
+          <div class="metric" data-value="32" data-decimals="0" data-duration="1500">
+            <div class="metric__title">Задержка</div>
             <div class="metric__value">
               <span class="metric__value-number">0</span>
+              <span class="metric__unit">мс</span>
             </div>
-            <div class="metric__unit">мс</div>
           </div>
         </div>
       </div>
@@ -151,10 +56,6 @@
         const body = document.body;
         body.classList.remove('no-js');
         const metrics = Array.from(document.querySelectorAll('.metric'));
-        const gearValue = document.querySelector('.dial__gear-value');
-        if (gearValue) {
-          gearValue.textContent = '—';
-        }
         const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         const bootDelay = reduceMotion ? 0 : 240;
         const betweenShift = reduceMotion ? 0 : 260;
@@ -213,12 +114,6 @@
             const target = Number(metric.dataset.value);
             const decimals = Number(metric.dataset.decimals || 0);
             const duration = Number(metric.dataset.duration || 1200);
-            const gear = metric.dataset.gear || '';
-
-            body.dataset.gear = gear;
-            if (gearValue) {
-              gearValue.textContent = gear || '—';
-            }
             metric.classList.add('metric--active');
             await animateValue(valueEl, target, decimals, duration);
             metric.classList.remove('metric--active');
@@ -227,10 +122,6 @@
           }
 
           await wait(coolDown);
-          body.dataset.gear = '';
-          if (gearValue) {
-            gearValue.textContent = '—';
-          }
           body.classList.add('is-finished');
         };
 

--- a/styles.css
+++ b/styles.css
@@ -177,51 +177,26 @@ body.is-finished .dial__gear-indicator {
 }
 
 .metrics {
-  position: relative;
-  z-index: 2;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: clamp(20px, 4.5vw, 50px);
-  padding: clamp(46px, 6.4vw, 70px) clamp(28px, 6vw, 64px) clamp(34px, 6vw, 60px);
-}
-
-.metrics::before {
-  content: "";
-  position: absolute;
-  inset: clamp(22px, 4.2vw, 40px) clamp(14px, 3.4vw, 32px);
-  border-radius: clamp(26px, 6vw, 60px);
-  background: linear-gradient(150deg, rgba(255, 0, 50, 0.14), rgba(12, 14, 18, 0.82));
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  opacity: 0.55;
-  z-index: -1;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(18px, 4vw, 44px);
+  margin-top: clamp(40px, 7vw, 74px);
 }
 
 .metric {
-  position: relative;
   display: grid;
   justify-items: center;
-  gap: clamp(10px, 2vw, 20px);
-  padding: clamp(22px, 3.4vw, 32px) clamp(18px, 3vw, 26px) clamp(28px, 4vw, 36px);
-  border-radius: clamp(24px, 5vw, 42px);
-  background: linear-gradient(165deg, rgba(25, 29, 36, 0.86), rgba(10, 12, 16, 0.72));
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-  opacity: 0.28;
-  transform: translateY(26px) scale(0.96);
-  transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
-    filter 0.6s ease, color 0.4s ease;
+  gap: clamp(12px, 2.4vw, 22px);
+  padding: clamp(24px, 4vw, 36px) clamp(18px, 3.6vw, 28px);
+  border-radius: clamp(22px, 4.4vw, 36px);
+  background: rgba(17, 20, 27, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.35);
+  opacity: 0.35;
+  transform: translateY(22px);
+  transition: opacity 0.45s ease, transform 0.5s ease, box-shadow 0.5s ease,
+    border-color 0.4s ease, background 0.4s ease;
   font-variant-numeric: tabular-nums;
-}
-
-.metric::before {
-  content: "";
-  position: absolute;
-  inset: 12px;
-  border-radius: inherit;
-  background: radial-gradient(circle at 50% 0%, rgba(255, 0, 50, 0.16), transparent 66%);
-  opacity: 0;
-  transition: opacity 0.4s ease;
-  pointer-events: none;
 }
 
 .metric__badge {
@@ -231,26 +206,25 @@ body.is-finished .dial__gear-indicator {
   padding: 4px 12px;
   border-radius: 999px;
   font-size: 0.75rem;
-  letter-spacing: 0.3em;
+  letter-spacing: 0.32em;
   text-transform: uppercase;
   background: rgba(255, 0, 50, 0.18);
-  border: 1px solid rgba(255, 0, 50, 0.36);
+  border: 1px solid rgba(255, 0, 50, 0.34);
   color: rgba(255, 255, 255, 0.78);
-  transition: transform 0.5s ease, background 0.4s ease, border-color 0.4s ease;
+  transition: background 0.4s ease, border-color 0.4s ease, transform 0.4s ease;
 }
 
 .metric__title {
-  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  font-size: clamp(1rem, 1.6vw, 1.24rem);
   color: var(--text-tertiary);
-  letter-spacing: 0.03em;
+  letter-spacing: 0.04em;
 }
 
 .metric__value {
-  font-size: clamp(2.6rem, 6vw, 3.7rem);
+  font-size: clamp(2.4rem, 5.6vw, 3.5rem);
   font-weight: 700;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   color: var(--text-primary);
-  text-shadow: 0 0 18px rgba(255, 0, 50, 0.32);
   display: flex;
   align-items: baseline;
   gap: 10px;
@@ -262,41 +236,43 @@ body.is-finished .dial__gear-indicator {
 }
 
 .metric__unit {
-  font-size: clamp(0.95rem, 1.4vw, 1.1rem);
+  font-size: clamp(0.9rem, 1.35vw, 1.05rem);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
 }
 
-.metric--active {
+.metric--active,
+.metric--complete {
   opacity: 1;
-  transform: translateY(0) scale(1.02);
-  filter: drop-shadow(0 20px 40px rgba(255, 0, 50, 0.35));
+  transform: translateY(0);
 }
 
-.metric--active::before {
-  opacity: 1;
+.metric--active {
+  background: rgba(24, 28, 36, 0.92);
+  border-color: rgba(255, 0, 50, 0.5);
+  box-shadow: 0 26px 60px rgba(255, 0, 50, 0.3);
 }
 
 .metric--active .metric__badge {
-  transform: translateY(-4px) scale(1.06);
+  transform: translateY(-3px);
   background: rgba(255, 0, 50, 0.28);
-  border-color: rgba(255, 0, 50, 0.6);
+  border-color: rgba(255, 0, 50, 0.62);
 }
 
 .metric--active .metric__title {
-  color: rgba(255, 255, 255, 0.85);
+  color: rgba(255, 255, 255, 0.88);
 }
 
 .metric--complete {
-  opacity: 0.9;
-  transform: translateY(0) scale(1);
-  filter: drop-shadow(0 16px 36px rgba(0, 0, 0, 0.35));
+  background: rgba(20, 23, 30, 0.88);
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
 }
 
 .metric--complete .metric__badge {
   background: rgba(255, 0, 50, 0.22);
-  border-color: rgba(255, 0, 50, 0.45);
+  border-color: rgba(255, 0, 50, 0.46);
 }
 
 .metric--complete .metric__title,
@@ -305,7 +281,6 @@ body.is-finished .dial__gear-indicator {
 }
 
 body.no-js .metric,
-body.no-js .metric::before,
 body.no-js .metric__badge,
 body.no-js .dial__progress-fill,
 body.no-js .dial__gear-indicator {
@@ -343,16 +318,19 @@ body.no-js .dial__gear-indicator {
 
 @media (max-width: 840px) {
   .metrics {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    padding: clamp(40px, 6vw, 64px) clamp(20px, 5vw, 44px) clamp(30px, 6vw, 54px);
-  }
-
-  .metrics::before {
-    inset: clamp(18px, 4vw, 34px) clamp(12px, 3vw, 28px);
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: clamp(16px, 5vw, 32px);
+    margin-top: clamp(34px, 9vw, 60px);
   }
 }
 
-@media (max-width: 580px) {
+@media (max-width: 640px) {
+  .metric {
+    padding: clamp(22px, 8vw, 32px) clamp(18px, 7vw, 28px);
+  }
+}
+
+@media (max-width: 560px) {
   .dial {
     border-radius: clamp(36px, 14vw, 80px);
     padding: clamp(28px, 9vw, 44px) clamp(22px, 8vw, 38px);
@@ -360,11 +338,7 @@ body.no-js .dial__gear-indicator {
 
   .metrics {
     grid-template-columns: 1fr;
-    gap: 28px;
-  }
-
-  .metric {
-    padding: clamp(24px, 6vw, 34px);
+    gap: clamp(20px, 8vw, 32px);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,17 @@
 :root {
   color-scheme: dark;
   font-family: "Manrope", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  --bg: #101214;
-  --panel: #15181d;
+  --bg: #0f1115;
+  --panel-bg: #161a21;
+  --panel-highlight: #1d212a;
   --panel-border: rgba(255, 255, 255, 0.06);
   --panel-soft: rgba(255, 255, 255, 0.04);
   --accent: #ff0032;
-  --accent-fade: rgba(255, 0, 50, 0.35);
+  --accent-soft: rgba(255, 0, 50, 0.35);
   --text-primary: #ffffff;
-  --text-secondary: rgba(255, 255, 255, 0.82);
-  --text-muted: rgba(255, 255, 255, 0.55);
+  --text-secondary: rgba(255, 255, 255, 0.84);
+  --text-tertiary: rgba(255, 255, 255, 0.6);
+  --text-muted: rgba(255, 255, 255, 0.45);
 }
 
 * {
@@ -23,107 +25,235 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(24px, 5vw, 48px);
-  background: radial-gradient(circle at 20% 20%, #171a1f 0%, #0a0b0d 55%, #040506 100%);
+  padding: clamp(24px, 6vw, 60px);
+  background: radial-gradient(circle at 18% 18%, #1a1e25 0%, #090b0f 62%, #05070a 100%);
   color: var(--text-primary);
   letter-spacing: 0.01em;
   -webkit-font-smoothing: antialiased;
 }
 
 .dashboard {
-  width: min(620px, 94vw);
+  width: min(940px, 94vw);
 }
 
 .dial {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: clamp(28px, 6vw, 40px);
-  padding: clamp(36px, 6vw, 56px);
-  border-radius: clamp(32px, 10vw, 52px);
-  background: var(--panel);
-  border: 1px solid var(--panel-border);
-  box-shadow: 0 26px 68px rgba(0, 0, 0, 0.48);
+  background: linear-gradient(160deg, var(--panel-bg), #10131a 72%);
+  border-radius: clamp(46px, 12vw, 160px);
+  padding: clamp(36px, 5vw, 60px) clamp(34px, 6.4vw, 78px);
+  box-shadow: 0 42px 110px rgba(0, 0, 0, 0.58), inset 0 0 0 1px var(--panel-border);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.dial::before {
+  content: "";
+  position: absolute;
+  inset: clamp(18px, 2.8vw, 36px);
+  border-radius: clamp(36px, 10vw, 120px);
+  background: radial-gradient(ellipse at 70% 18%, rgba(255, 0, 50, 0.18), transparent 68%),
+    radial-gradient(ellipse at 30% 82%, rgba(255, 0, 50, 0.12), transparent 72%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(0, 0, 0, 0.35));
+  opacity: 0.85;
+  z-index: 0;
 }
 
 .dial__frame {
-  display: block;
-  width: min(320px, 72vw);
-  height: auto;
-}
-
-.dial__ring-track,
-.dial__ring-fill {
+  position: absolute;
+  inset: clamp(12px, 2.3vw, 28px);
+  width: calc(100% - 2 * clamp(12px, 2.3vw, 28px));
+  height: calc(100% - 2 * clamp(12px, 2.3vw, 28px));
+  z-index: 1;
   fill: none;
-  stroke-width: 12;
+  pointer-events: none;
+}
+
+.dial__progress-track,
+.dial__progress-fill,
+.dial__outline,
+.dial__inner {
+  fill: none;
   stroke-linecap: round;
-  transform: rotate(-90deg);
-  transform-origin: 50% 50%;
-  transform-box: fill-box;
+  stroke-linejoin: round;
 }
 
-.dial__ring-track {
-  stroke: rgba(255, 255, 255, 0.08);
+.dial__progress-track {
+  stroke: url(#dial-track-gradient);
+  stroke-width: 6;
 }
 
-.dial__ring-fill {
+.dial__progress-fill {
   stroke: url(#dial-progress-gradient);
+  stroke-width: 6;
   stroke-dasharray: 100;
   stroke-dashoffset: 100;
   opacity: 0;
-  filter: drop-shadow(0 10px 24px var(--accent-fade));
+  filter: drop-shadow(0 0 18px var(--accent-soft));
 }
 
-.dial__ring-center {
-  fill: rgba(255, 255, 255, 0.03);
+.dial__face {
+  fill: rgba(12, 15, 21, 0.85);
+  stroke: rgba(255, 255, 255, 0.04);
+  stroke-width: 1;
+  filter: drop-shadow(0 28px 60px rgba(0, 0, 0, 0.45));
 }
 
-body.is-ready .dial__ring-fill {
+.dial__outline {
+  stroke: url(#dial-outline-gradient);
+  stroke-width: 3;
+  opacity: 0.9;
+}
+
+.dial__inner {
+  stroke: rgba(255, 255, 255, 0.14);
+  stroke-width: 2;
+  stroke-dasharray: 16 14;
+  opacity: 0.6;
+}
+
+body.is-ready .dial__progress-fill {
   opacity: 1;
-  animation: dial-progress 3.1s cubic-bezier(0.22, 0.87, 0.36, 1) forwards;
+  animation: dial-progress 3.2s cubic-bezier(0.22, 0.87, 0.36, 1) forwards;
 }
 
-body.is-finished .dial__ring-fill {
+body.is-finished .dial__progress-fill {
   stroke: var(--accent);
 }
 
+.dial__gear-indicator {
+  position: absolute;
+  top: clamp(32px, 6vw, 80px);
+  left: 50%;
+  transform: translate(-50%, -8px);
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 22px;
+  border-radius: 999px;
+  background: rgba(14, 16, 22, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  font-size: 0.78rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.58);
+  z-index: 3;
+  opacity: 0;
+  transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
+    background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.dial__gear-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.42em;
+  color: rgba(255, 255, 255, 0.38);
+}
+
+.dial__gear-value {
+  font-size: 1.1rem;
+  min-width: 2ch;
+  text-align: center;
+}
+
+body.is-ready .dial__gear-indicator {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+body[data-gear]:not([data-gear=""]) .dial__gear-indicator {
+  background: rgba(255, 0, 50, 0.2);
+  border-color: rgba(255, 0, 50, 0.42);
+  color: rgba(255, 255, 255, 0.76);
+  box-shadow: 0 20px 44px rgba(255, 0, 50, 0.25);
+}
+
+body[data-gear]:not([data-gear=""]) .dial__gear-value {
+  color: #ffffff;
+}
+
+body.is-finished .dial__gear-indicator {
+  opacity: 0;
+  transform: translate(-50%, -12px);
+}
+
 .metrics {
-  width: 100%;
+  position: relative;
+  z-index: 2;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: clamp(18px, 5vw, 28px);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(20px, 4.5vw, 50px);
+  padding: clamp(46px, 6.4vw, 70px) clamp(28px, 6vw, 64px) clamp(34px, 6vw, 60px);
+}
+
+.metrics::before {
+  content: "";
+  position: absolute;
+  inset: clamp(22px, 4.2vw, 40px) clamp(14px, 3.4vw, 32px);
+  border-radius: clamp(26px, 6vw, 60px);
+  background: linear-gradient(150deg, rgba(255, 0, 50, 0.14), rgba(12, 14, 18, 0.82));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  opacity: 0.55;
+  z-index: -1;
 }
 
 .metric {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: clamp(20px, 4vw, 28px);
-  border-radius: clamp(20px, 6vw, 28px);
-  background: var(--panel-soft);
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: clamp(10px, 2vw, 20px);
+  padding: clamp(22px, 3.4vw, 32px) clamp(18px, 3vw, 26px) clamp(28px, 4vw, 36px);
+  border-radius: clamp(24px, 5vw, 42px);
+  background: linear-gradient(165deg, rgba(25, 29, 36, 0.86), rgba(10, 12, 16, 0.72));
   border: 1px solid rgba(255, 255, 255, 0.05);
-  opacity: 0.35;
-  transform: translateY(12px);
-  transition: opacity 0.45s ease, transform 0.5s cubic-bezier(0.22, 0.87, 0.36, 1);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  opacity: 0.28;
+  transform: translateY(26px) scale(0.96);
+  transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
+    filter 0.6s ease, color 0.4s ease;
   font-variant-numeric: tabular-nums;
 }
 
+.metric::before {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: inherit;
+  background: radial-gradient(circle at 50% 0%, rgba(255, 0, 50, 0.16), transparent 66%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+}
+
+.metric__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  background: rgba(255, 0, 50, 0.18);
+  border: 1px solid rgba(255, 0, 50, 0.36);
+  color: rgba(255, 255, 255, 0.78);
+  transition: transform 0.5s ease, background 0.4s ease, border-color 0.4s ease;
+}
+
 .metric__title {
-  font-size: clamp(0.95rem, 1.6vw, 1.2rem);
-  font-weight: 600;
+  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  color: var(--text-tertiary);
   letter-spacing: 0.03em;
-  color: var(--text-muted);
 }
 
 .metric__value {
+  font-size: clamp(2.6rem, 6vw, 3.7rem);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--text-primary);
+  text-shadow: 0 0 18px rgba(255, 0, 50, 0.32);
   display: flex;
   align-items: baseline;
   gap: 10px;
-  font-size: clamp(2.4rem, 6vw, 3.2rem);
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  color: var(--text-primary);
 }
 
 .metric__value-number {
@@ -132,7 +262,7 @@ body.is-finished .dial__ring-fill {
 }
 
 .metric__unit {
-  font-size: clamp(0.85rem, 1.3vw, 1rem);
+  font-size: clamp(0.95rem, 1.4vw, 1.1rem);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
@@ -140,12 +270,33 @@ body.is-finished .dial__ring-fill {
 
 .metric--active {
   opacity: 1;
-  transform: translateY(0);
+  transform: translateY(0) scale(1.02);
+  filter: drop-shadow(0 20px 40px rgba(255, 0, 50, 0.35));
+}
+
+.metric--active::before {
+  opacity: 1;
+}
+
+.metric--active .metric__badge {
+  transform: translateY(-4px) scale(1.06);
+  background: rgba(255, 0, 50, 0.28);
+  border-color: rgba(255, 0, 50, 0.6);
+}
+
+.metric--active .metric__title {
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .metric--complete {
-  opacity: 0.85;
-  transform: translateY(0);
+  opacity: 0.9;
+  transform: translateY(0) scale(1);
+  filter: drop-shadow(0 16px 36px rgba(0, 0, 0, 0.35));
+}
+
+.metric--complete .metric__badge {
+  background: rgba(255, 0, 50, 0.22);
+  border-color: rgba(255, 0, 50, 0.45);
 }
 
 .metric--complete .metric__title,
@@ -153,34 +304,67 @@ body.is-finished .dial__ring-fill {
   color: var(--text-secondary);
 }
 
+body.no-js .metric,
+body.no-js .metric::before,
+body.no-js .metric__badge,
+body.no-js .dial__progress-fill,
+body.no-js .dial__gear-indicator {
+  animation: none;
+  transition: none;
+}
+
 body.no-js .metric {
   opacity: 1;
   transform: none;
 }
 
-body.no-js .dial__ring-fill {
+body.no-js .dial__progress-fill {
   opacity: 1;
   stroke-dashoffset: 0;
-  animation: none;
+}
+
+body.no-js .dial__gear-indicator {
+  display: none;
 }
 
 @keyframes dial-progress {
-  from {
+  0% {
     stroke-dashoffset: 100;
+    opacity: 0;
   }
-  to {
+  15% {
+    opacity: 1;
+  }
+  100% {
     stroke-dashoffset: 0;
+    opacity: 1;
   }
 }
 
-@media (max-width: 600px) {
-  .dial {
-    padding: clamp(28px, 8vw, 44px);
-    border-radius: clamp(28px, 12vw, 42px);
+@media (max-width: 840px) {
+  .metrics {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    padding: clamp(40px, 6vw, 64px) clamp(20px, 5vw, 44px) clamp(30px, 6vw, 54px);
   }
 
-  .metric__value-number {
-    min-width: 4ch;
+  .metrics::before {
+    inset: clamp(18px, 4vw, 34px) clamp(12px, 3vw, 28px);
+  }
+}
+
+@media (max-width: 580px) {
+  .dial {
+    border-radius: clamp(36px, 14vw, 80px);
+    padding: clamp(28px, 9vw, 44px) clamp(22px, 8vw, 38px);
+  }
+
+  .metrics {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+
+  .metric {
+    padding: clamp(24px, 6vw, 34px);
   }
 }
 
@@ -194,7 +378,7 @@ body.no-js .dial__ring-fill {
     scroll-behavior: auto !important;
   }
 
-  body.is-ready .dial__ring-fill {
+  body.is-ready .dial__progress-fill {
     stroke-dashoffset: 0;
     opacity: 1;
   }

--- a/styles.css
+++ b/styles.css
@@ -2,17 +2,14 @@
   color-scheme: dark;
   font-family: "Manrope", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   --bg: #101214;
-  --panel-bg: #14161a;
-  --panel-shadow: rgba(0, 0, 0, 0.55);
-  --panel-inner: #0d0e10;
-  --panel-stroke: rgba(255, 255, 255, 0.06);
+  --panel: #15181d;
+  --panel-border: rgba(255, 255, 255, 0.06);
+  --panel-soft: rgba(255, 255, 255, 0.04);
   --accent: #ff0032;
-  --accent-strong: #ff2247;
-  --accent-soft: rgba(255, 0, 50, 0.55);
-  --accent-glow: rgba(255, 0, 50, 0.32);
+  --accent-fade: rgba(255, 0, 50, 0.35);
   --text-primary: #ffffff;
-  --text-secondary: #c5c8ce;
-  --text-tertiary: rgba(255, 255, 255, 0.64);
+  --text-secondary: rgba(255, 255, 255, 0.82);
+  --text-muted: rgba(255, 255, 255, 0.55);
 }
 
 * {
@@ -26,360 +23,134 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: radial-gradient(circle at 20% 20%, #181a1f 0%, #08090b 65%, #040506 100%);
+  padding: clamp(24px, 5vw, 48px);
+  background: radial-gradient(circle at 20% 20%, #171a1f 0%, #0a0b0d 55%, #040506 100%);
   color: var(--text-primary);
   letter-spacing: 0.01em;
   -webkit-font-smoothing: antialiased;
 }
 
 .dashboard {
-  width: min(940px, 94vw);
+  width: min(620px, 94vw);
 }
 
 .dial {
   position: relative;
-  background: linear-gradient(145deg, var(--panel-bg), #0a0c0f 70%);
-  padding: clamp(36px, 5.5vw, 64px) clamp(28px, 6vw, 72px);
-  border-radius: clamp(50px, 12vw, 170px);
-  box-shadow: 0 40px 90px var(--panel-shadow), inset 0 0 0 1px var(--panel-stroke);
-  overflow: hidden;
-  isolation: isolate;
-}
-
-.dial::before {
-  content: "";
-  position: absolute;
-  inset: clamp(18px, 2.6vw, 34px);
-  border-radius: clamp(38px, 10vw, 130px);
-  background: radial-gradient(ellipse at 60% 20%, rgba(255, 0, 50, 0.12), transparent 70%),
-    radial-gradient(ellipse at 30% 80%, rgba(255, 0, 50, 0.1), transparent 70%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(0, 0, 0, 0.5));
-  z-index: 0;
-  opacity: 0.85;
-}
-
-.dial::after {
-  content: "";
-  position: absolute;
-  inset: clamp(32px, 5vw, 56px);
-  border-radius: clamp(30px, 9vw, 120px);
-  background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.04), transparent 65%),
-    radial-gradient(circle at 50% 80%, rgba(255, 0, 50, 0.12), transparent 65%);
-  z-index: 0;
-  opacity: 0.75;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(28px, 6vw, 40px);
+  padding: clamp(36px, 6vw, 56px);
+  border-radius: clamp(32px, 10vw, 52px);
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 26px 68px rgba(0, 0, 0, 0.48);
 }
 
 .dial__frame {
-  position: absolute;
-  inset: clamp(12px, 2.2vw, 28px);
-  width: calc(100% - 2 * clamp(12px, 2.2vw, 28px));
-  height: calc(100% - 2 * clamp(12px, 2.2vw, 28px));
-  z-index: 1;
+  display: block;
+  width: min(320px, 72vw);
+  height: auto;
+}
+
+.dial__ring-track,
+.dial__ring-fill {
   fill: none;
-  pointer-events: none;
-}
-
-.dial__gear-indicator {
-  position: absolute;
-  top: clamp(36px, 6vw, 82px);
-  left: 50%;
-  transform: translate(-50%, -10px);
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 20px;
-  border-radius: 999px;
-  background: rgba(10, 11, 14, 0.72);
-  border: 1px solid rgba(255, 0, 50, 0.28);
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
-  font-size: 0.78rem;
-  letter-spacing: 0.32em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
-  z-index: 3;
-  opacity: 0;
-  transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
-    background 0.3s ease, border-color 0.3s ease;
-}
-
-.dial__gear-label {
-  font-size: 0.7rem;
-  letter-spacing: 0.42em;
-  color: rgba(255, 255, 255, 0.38);
-}
-
-.dial__gear-value {
-  font-size: 1.1rem;
-  color: rgba(255, 255, 255, 0.65);
-  min-width: 2ch;
-  text-align: center;
-}
-
-body.is-ready .dial__gear-indicator {
-  opacity: 1;
-  transform: translate(-50%, 0);
-}
-
-body[data-gear]:not([data-gear=""]) .dial__gear-indicator {
-  background: rgba(255, 0, 50, 0.18);
-  border-color: rgba(255, 0, 50, 0.45);
-  box-shadow: 0 18px 44px rgba(255, 0, 50, 0.24);
-  color: rgba(255, 255, 255, 0.72);
-}
-
-body[data-gear]:not([data-gear=""]) .dial__gear-value {
-  color: #ffffff;
-}
-
-body.is-finished .dial__gear-indicator {
-  opacity: 0;
-  transform: translate(-50%, -12px);
-}
-
-.dial__accent {
-  filter: drop-shadow(0 0 14px rgba(255, 0, 50, 0.45)) drop-shadow(0 0 44px rgba(255, 0, 50, 0.35));
-}
-
-.dial__mesh {
-  fill: url(#dial-grid);
-  mix-blend-mode: screen;
-  opacity: 0.82;
-}
-
-.dial__grid-bar {
-  fill: rgba(255, 0, 50, 0.22);
-}
-
-.dial__grid-bar--major {
-  opacity: 0.85;
-}
-
-.dial__grid-bar--minor {
-  opacity: 0.55;
-}
-
-.dial__pulse {
-  fill: none;
-  stroke: rgba(255, 0, 50, 0.55);
-  stroke-width: 3;
-  stroke-dasharray: 2.5 14;
+  stroke-width: 12;
   stroke-linecap: round;
-  stroke-dashoffset: 6;
-  animation: dial-pulse 2.4s linear infinite;
+  transform: rotate(-90deg);
+  transform-origin: 50% 50%;
+  transform-box: fill-box;
 }
 
-.dial__outline {
-  fill: none;
-  stroke: url(#dial-outline-gradient);
-  stroke-width: 3;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  opacity: 0.95;
+.dial__ring-track {
+  stroke: rgba(255, 255, 255, 0.08);
 }
 
-.dial__inner {
-  fill: none;
-  stroke: url(#dial-inner-gradient);
-  stroke-width: 2;
-  opacity: 0.8;
-  stroke-dasharray: 14 10;
-  stroke-linecap: round;
-}
-
-.dial__corner-sparks {
-  fill: none;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.dial__corner {
-  stroke: rgba(255, 0, 50, 0.55);
-  stroke-width: 4;
-  stroke-dasharray: 18 22;
-  stroke-dashoffset: 14;
-  opacity: 0.75;
-  animation: dial-corner 3.2s ease-in-out infinite;
-}
-
-.dial__progress-track,
-.dial__progress-fill {
-  fill: none;
-  stroke-width: 6;
-  stroke-linecap: round;
-}
-
-.dial__progress-track {
-  stroke: rgba(255, 0, 50, 0.18);
-}
-
-.dial__progress-fill {
-  stroke: rgba(255, 0, 50, 0.65);
+.dial__ring-fill {
+  stroke: url(#dial-progress-gradient);
   stroke-dasharray: 100;
   stroke-dashoffset: 100;
   opacity: 0;
-  filter: drop-shadow(0 0 20px var(--accent-glow));
+  filter: drop-shadow(0 10px 24px var(--accent-fade));
 }
 
-body.is-ready .dial__progress-fill {
+.dial__ring-center {
+  fill: rgba(255, 255, 255, 0.03);
+}
+
+body.is-ready .dial__ring-fill {
   opacity: 1;
-  animation: dial-progress 3.4s cubic-bezier(0.21, 0.85, 0.32, 1) forwards;
+  animation: dial-progress 3.1s cubic-bezier(0.22, 0.87, 0.36, 1) forwards;
 }
 
-body.is-finished .dial__progress-fill {
+body.is-finished .dial__ring-fill {
   stroke: var(--accent);
 }
 
 .metrics {
-  position: relative;
-  z-index: 2;
+  width: 100%;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: clamp(18px, 4vw, 46px);
-  padding: clamp(48px, 7vw, 72px) clamp(30px, 6vw, 68px) clamp(36px, 6vw, 60px);
-}
-
-.metrics::before {
-  content: "";
-  position: absolute;
-  inset: clamp(24px, 4vw, 40px) clamp(12px, 3vw, 30px);
-  border-radius: clamp(26px, 6vw, 60px);
-  background: linear-gradient(145deg, rgba(255, 0, 50, 0.12), rgba(10, 11, 14, 0.8));
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  filter: blur(0.5px);
-  opacity: 0.6;
-  z-index: -1;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: clamp(18px, 5vw, 28px);
 }
 
 .metric {
-  position: relative;
-  display: grid;
-  justify-items: center;
-  gap: clamp(10px, 2vw, 18px);
-  padding: clamp(20px, 3vw, 28px) clamp(16px, 3vw, 24px) clamp(28px, 4vw, 34px);
-  border-radius: clamp(24px, 5vw, 42px);
-  background: linear-gradient(160deg, rgba(20, 22, 26, 0.85), rgba(7, 8, 10, 0.7));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: clamp(20px, 4vw, 28px);
+  border-radius: clamp(20px, 6vw, 28px);
+  background: var(--panel-soft);
   border: 1px solid rgba(255, 255, 255, 0.05);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-  opacity: 0.25;
-  transform: translateY(24px) scale(0.96);
-  transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
-    filter 0.6s ease;
+  opacity: 0.35;
+  transform: translateY(12px);
+  transition: opacity 0.45s ease, transform 0.5s cubic-bezier(0.22, 0.87, 0.36, 1);
   font-variant-numeric: tabular-nums;
 }
 
-.metric::before {
-  content: "";
-  position: absolute;
-  inset: 12px;
-  border-radius: inherit;
-  background: radial-gradient(circle at 50% 0%, rgba(255, 0, 50, 0.16), transparent 65%);
-  opacity: 0;
-  transition: opacity 0.4s ease;
-  pointer-events: none;
-}
-
-.metric__badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 4px 12px;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  letter-spacing: 0.32em;
-  text-transform: uppercase;
-  background: rgba(255, 0, 50, 0.18);
-  border: 1px solid rgba(255, 0, 50, 0.36);
-  color: rgba(255, 255, 255, 0.78);
-  transition: transform 0.5s ease, background 0.4s ease, border-color 0.4s ease;
-}
-
 .metric__title {
-  font-size: clamp(1rem, 1.6vw, 1.25rem);
-  color: var(--text-secondary);
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  letter-spacing: 0.03em;
-}
-
-.metric__hint {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  color: rgba(255, 255, 255, 0.6);
-  font-size: 0.85rem;
+  font-size: clamp(0.95rem, 1.6vw, 1.2rem);
   font-weight: 600;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
 }
 
 .metric__value {
-  font-size: clamp(2.6rem, 6vw, 3.8rem);
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: clamp(2.4rem, 6vw, 3.2rem);
   font-weight: 700;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
   color: var(--text-primary);
-  text-shadow: 0 0 18px rgba(255, 0, 50, 0.35);
-  transition: color 0.45s ease;
 }
 
 .metric__value-number {
-  display: inline-block;
   min-width: 5ch;
   text-align: center;
 }
 
 .metric__unit {
-  font-size: clamp(0.95rem, 1.4vw, 1.1rem);
-  color: var(--text-tertiary);
+  font-size: clamp(0.85rem, 1.3vw, 1rem);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  color: var(--text-muted);
 }
 
 .metric--active {
   opacity: 1;
-  transform: translateY(0) scale(1.02);
-  filter: drop-shadow(0 20px 40px rgba(255, 0, 50, 0.38));
-}
-
-.metric--active::before {
-  opacity: 1;
-}
-
-.metric--active .metric__badge {
-  transform: translateY(-4px) scale(1.08);
-  background: rgba(255, 0, 50, 0.32);
-  border-color: rgba(255, 0, 50, 0.65);
-}
-
-.metric--active .metric__title {
-  color: rgba(255, 255, 255, 0.82);
+  transform: translateY(0);
 }
 
 .metric--complete {
-  opacity: 0.92;
-  transform: translateY(0) scale(1);
-  filter: drop-shadow(0 16px 32px rgba(0, 0, 0, 0.35));
+  opacity: 0.85;
+  transform: translateY(0);
 }
 
-.metric--complete .metric__value {
-  color: #ffffff;
-}
-
-.metric--complete .metric__badge {
-  background: rgba(255, 0, 50, 0.24);
-  border-color: rgba(255, 0, 50, 0.45);
-}
-
-body.no-js .metric,
-body.no-js .metric::before,
-body.no-js .metric__badge,
-body.no-js .dial__progress-fill,
-body.no-js .dial__corner,
-body.no-js .dial__pulse {
-  animation: none;
-  transition: none;
+.metric--complete .metric__title,
+.metric--complete .metric__unit {
+  color: var(--text-secondary);
 }
 
 body.no-js .metric {
@@ -387,76 +158,29 @@ body.no-js .metric {
   transform: none;
 }
 
-body.no-js .dial__progress-fill {
+body.no-js .dial__ring-fill {
   opacity: 1;
   stroke-dashoffset: 0;
-}
-
-body.no-js .dial__gear-indicator {
-  display: none;
-}
-
-@media (max-width: 840px) {
-  .metrics {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    padding: clamp(40px, 6vw, 64px) clamp(18px, 5vw, 44px) clamp(28px, 6vw, 54px);
-  }
-
-  .metrics::before {
-    inset: clamp(18px, 4vw, 34px) clamp(12px, 3vw, 28px);
-  }
-}
-
-@media (max-width: 580px) {
-  .metrics {
-    grid-template-columns: 1fr;
-    gap: 28px;
-  }
-
-  .metric {
-    padding: clamp(24px, 6vw, 34px);
-  }
-}
-
-@keyframes dial-pulse {
-  from {
-    stroke-dashoffset: 6;
-  }
-  to {
-    stroke-dashoffset: -20;
-  }
-}
-
-@keyframes dial-corner {
-  0% {
-    stroke-dashoffset: 14;
-    opacity: 0.35;
-  }
-  45% {
-    opacity: 0.85;
-  }
-  100% {
-    stroke-dashoffset: -26;
-    opacity: 0.45;
-  }
+  animation: none;
 }
 
 @keyframes dial-progress {
-  0% {
+  from {
     stroke-dashoffset: 100;
-    opacity: 0;
   }
-  12% {
-    opacity: 1;
-  }
-  38% {
-    stroke-dashoffset: 68;
-  }
-  68% {
-    stroke-dashoffset: 28;
-  }
-  100% {
+  to {
     stroke-dashoffset: 0;
+  }
+}
+
+@media (max-width: 600px) {
+  .dial {
+    padding: clamp(28px, 8vw, 44px);
+    border-radius: clamp(28px, 12vw, 42px);
+  }
+
+  .metric__value-number {
+    min-width: 4ch;
   }
 }
 
@@ -470,7 +194,7 @@ body.no-js .dial__gear-indicator {
     scroll-behavior: auto !important;
   }
 
-  body.is-ready .dial__progress-fill {
+  body.is-ready .dial__ring-fill {
     stroke-dashoffset: 0;
     opacity: 1;
   }


### PR DESCRIPTION
## Summary
- replace the decorative dial frame with a compact circular progress ring
- streamline the metric cards to just the core title, value, and unit content
- update the sequencing script and styling to match the reduced, minimal presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc85d201988321b9a589595c76dc35