### PR TITLE
Add animated advantages speedometer section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Скорость подключения</title>
+    <title>Преимущества оптовых поставок из Японии</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -13,8 +13,18 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body class="no-js">
-    <main class="dashboard">
+    <main class="advantages">
+      <header class="advantages__header">
+        <span class="advantages__eyebrow">Преимущества партнёрам</span>
+        <h1 class="advantages__title">Скорость оптовых поставок из Японии</h1>
+        <p class="advantages__subtitle">
+          Комбинируем японскую точность и российскую логистику: груз проходит контроль
+          без задержек, а клиенты получают оригинальные узлы и агрегаты с гарантией.
+        </p>
+      </header>
       <div class="dial">
+        <div class="dial__halo" aria-hidden="true"></div>
+        <div class="dial__kanji" aria-hidden="true">迅速</div>
         <svg class="dial__frame" viewBox="0 0 900 360" aria-hidden="true">
           <defs>
             <linearGradient id="dial-outline-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -105,43 +115,111 @@
             </g>
           </g>
         </svg>
+        <div class="dial__crest" aria-hidden="true">
+          <span class="dial__crest-label">JP</span>
+          <span class="dial__crest-arrow">➜</span>
+          <span class="dial__crest-label">RU</span>
+        </div>
+        <div class="dial__needle" data-home-angle="-128" aria-hidden="true"></div>
         <div class="dial__gear-indicator" aria-hidden="true">
           <span class="dial__gear-label">Передача</span>
           <span class="dial__gear-value">—</span>
+          <span class="dial__gear-mode"></span>
         </div>
         <div class="metrics">
-          <div class="metric" data-gear="I" data-value="27.18" data-decimals="2" data-duration="1400">
+          <div
+            class="metric"
+            data-gear="I"
+            data-mode="Tokyo Express"
+            data-angle="-112"
+            data-value="24"
+            data-prefix="≤ "
+            data-suffix=" ч"
+            data-duration="1600"
+          >
             <div class="metric__badge" aria-hidden="true">I</div>
             <div class="metric__title">
-              Входящая
+              Отгрузка со склада
               <span class="metric__hint" aria-hidden="true">i</span>
             </div>
             <div class="metric__value">
-              <span class="metric__value-number">0</span>
+              <span class="metric__value-number">≤ 24 ч</span>
             </div>
-            <div class="metric__unit">Мбит/с</div>
+            <div class="metric__unit">с момента оплаты</div>
+            <p class="metric__description">
+              Собственный московский хаб выпускает подтверждённые заказы в день оплаты и берёт на
+              себя упаковку.
+            </p>
           </div>
-          <div class="metric" data-gear="II" data-value="30.28" data-decimals="2" data-duration="1200">
+          <div
+            class="metric"
+            data-gear="II"
+            data-mode="Osaka Stock"
+            data-angle="-36"
+            data-value="12500"
+            data-suffix="+"
+            data-duration="1500"
+          >
             <div class="metric__badge" aria-hidden="true">II</div>
             <div class="metric__title">
-              Исходящая
+              Оригинальные артикула
               <span class="metric__hint" aria-hidden="true">i</span>
             </div>
             <div class="metric__value">
-              <span class="metric__value-number">0</span>
+              <span class="metric__value-number">12&nbsp;500+</span>
             </div>
-            <div class="metric__unit">Мбит/с</div>
+            <div class="metric__unit">в наличии и под заказ</div>
+            <p class="metric__description">
+              Прямая закупка у японских производителей и аукционов: редкие позиции держим в резерве и
+              поставляем под VIN.
+            </p>
           </div>
-          <div class="metric" data-gear="III" data-value="32" data-decimals="0" data-duration="1500">
+          <div
+            class="metric"
+            data-gear="III"
+            data-mode="Nagoya QC"
+            data-angle="42"
+            data-value="99.6"
+            data-decimals="1"
+            data-suffix=" %"
+            data-duration="1700"
+          >
             <div class="metric__badge" aria-hidden="true">III</div>
             <div class="metric__title">
-              Задержка
+              Успешное оформление
               <span class="metric__hint" aria-hidden="true">i</span>
             </div>
             <div class="metric__value">
-              <span class="metric__value-number">0</span>
+              <span class="metric__value-number">99,6 %</span>
             </div>
-            <div class="metric__unit">мс</div>
+            <div class="metric__unit">таможенное сопровождение</div>
+            <p class="metric__description">
+              Команда в Нагое проверяет партии и готовит документы, сокращая возвраты практически до
+              нуля.
+            </p>
+          </div>
+          <div
+            class="metric"
+            data-gear="IV"
+            data-mode="Sapporo Warranty"
+            data-angle="118"
+            data-value="12"
+            data-suffix=" мес"
+            data-duration="1500"
+          >
+            <div class="metric__badge" aria-hidden="true">IV</div>
+            <div class="metric__title">
+              Расширенная гарантия
+              <span class="metric__hint" aria-hidden="true">i</span>
+            </div>
+            <div class="metric__value">
+              <span class="metric__value-number">12 мес</span>
+            </div>
+            <div class="metric__unit">на агрегаты и ДВС</div>
+            <p class="metric__description">
+              Инженеры в Саппоро тестируют узлы на стендах, а мы закрепляем поставку договорной
+              гарантией.
+            </p>
           </div>
         </div>
       </div>
@@ -152,13 +230,25 @@
         body.classList.remove('no-js');
         const metrics = Array.from(document.querySelectorAll('.metric'));
         const gearValue = document.querySelector('.dial__gear-value');
+        const gearMode = document.querySelector('.dial__gear-mode');
+        const needle = document.querySelector('.dial__needle');
+        const homeAngle = needle ? Number(needle.dataset.homeAngle || -128) : -128;
+
         if (gearValue) {
           gearValue.textContent = '—';
         }
+        if (gearMode) {
+          gearMode.textContent = '';
+        }
+        if (needle) {
+          needle.style.setProperty('--needle-angle', `${homeAngle}deg`);
+        }
+
         const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         const bootDelay = reduceMotion ? 0 : 240;
         const betweenShift = reduceMotion ? 0 : 260;
         const coolDown = reduceMotion ? 0 : 320;
+
         if (!metrics.length) {
           body.classList.add('is-ready');
           return;
@@ -167,21 +257,32 @@
         const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
         const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
 
-        const animateValue = (element, target, decimals, duration) => {
+        const animateValue = (element, target, decimals, duration, prefix = '', suffix = '') => {
           return new Promise((resolve) => {
+            if (!element) {
+              resolve();
+              return;
+            }
             const effectiveDuration = reduceMotion ? 0 : duration;
             const start = performance.now();
             const startValue = 0;
 
-            const format = (value) => {
+            const formatNumber = (value) => {
               if (decimals > 0) {
-                return value.toFixed(decimals);
+                return Number(value).toLocaleString('ru-RU', {
+                  minimumFractionDigits: decimals,
+                  maximumFractionDigits: decimals,
+                });
               }
-              return Math.round(value).toString();
+              return Math.round(value).toLocaleString('ru-RU');
+            };
+
+            const setValue = (value) => {
+              element.textContent = `${prefix}${value}${suffix}`;
             };
 
             if (effectiveDuration === 0) {
-              element.textContent = format(target);
+              setValue(formatNumber(target));
               resolve();
               return;
             }
@@ -190,12 +291,12 @@
               const progress = Math.min((now - start) / effectiveDuration, 1);
               const eased = easeOutCubic(progress);
               const current = startValue + (target - startValue) * eased;
-              element.textContent = format(current);
+              setValue(formatNumber(current));
 
               if (progress < 1) {
                 requestAnimationFrame(update);
               } else {
-                element.textContent = format(target);
+                setValue(formatNumber(target));
                 resolve();
               }
             };
@@ -214,13 +315,33 @@
             const decimals = Number(metric.dataset.decimals || 0);
             const duration = Number(metric.dataset.duration || 1200);
             const gear = metric.dataset.gear || '';
+            const mode = metric.dataset.mode || '';
+            const prefix = metric.dataset.prefix || '';
+            const suffix = metric.dataset.suffix || '';
+            const angle =
+              typeof metric.dataset.angle !== 'undefined'
+                ? Number(metric.dataset.angle)
+                : homeAngle;
+
+            if (valueEl) {
+              valueEl.textContent = '0';
+            }
 
             body.dataset.gear = gear;
+            body.dataset.mode = mode;
+
             if (gearValue) {
               gearValue.textContent = gear || '—';
             }
+            if (gearMode) {
+              gearMode.textContent = mode;
+            }
+            if (needle) {
+              needle.style.setProperty('--needle-angle', `${angle}deg`);
+            }
+
             metric.classList.add('metric--active');
-            await animateValue(valueEl, target, decimals, duration);
+            await animateValue(valueEl, target, decimals, duration, prefix, suffix);
             metric.classList.remove('metric--active');
             metric.classList.add('metric--complete');
             await wait(betweenShift);
@@ -228,8 +349,15 @@
 
           await wait(coolDown);
           body.dataset.gear = '';
+          body.dataset.mode = '';
           if (gearValue) {
             gearValue.textContent = '—';
+          }
+          if (gearMode) {
+            gearMode.textContent = '';
+          }
+          if (needle) {
+            needle.style.setProperty('--needle-angle', `${homeAngle}deg`);
           }
           body.classList.add('is-finished');
         };

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 :root {
   color-scheme: dark;
   font-family: "Manrope", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  --bg: #101214;
+  --bg: #090b0f;
   --panel-bg: #14161a;
   --panel-shadow: rgba(0, 0, 0, 0.55);
   --panel-inner: #0d0e10;
@@ -26,22 +26,100 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: radial-gradient(circle at 20% 20%, #181a1f 0%, #08090b 65%, #040506 100%);
+  padding: clamp(48px, 8vh, 96px) clamp(24px, 6vw, 72px);
+  background: radial-gradient(circle at 20% 20%, #181a1f 0%, #090b0f 60%, #040506 100%);
   color: var(--text-primary);
   letter-spacing: 0.01em;
+  line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
 }
 
-.dashboard {
-  width: min(940px, 94vw);
+body::before {
+  content: "";
+  position: absolute;
+  width: clamp(320px, 58vw, 540px);
+  height: clamp(320px, 58vw, 540px);
+  border-radius: 50%;
+  background: radial-gradient(
+      circle,
+      rgba(255, 78, 110, 0.45) 0%,
+      rgba(255, 0, 50, 0.65) 46%,
+      rgba(255, 0, 50, 0.12) 72%,
+      transparent 100%
+    );
+  top: clamp(-220px, -20vw, -80px);
+  right: clamp(-140px, -6vw, 40px);
+  filter: blur(12px);
+  opacity: 0.7;
+  z-index: 0;
+}
+
+body::after {
+  content: "";
+  position: absolute;
+  inset: -18%;
+  background: radial-gradient(circle at 12% 78%, rgba(255, 255, 255, 0.08), transparent 52%),
+    repeating-linear-gradient(125deg, rgba(255, 255, 255, 0.05) 0 1px, transparent 1px 9px);
+  opacity: 0.1;
+  z-index: 0;
+}
+
+.advantages {
+  position: relative;
+  z-index: 1;
+  width: min(1080px, 96vw);
+  display: grid;
+  gap: clamp(32px, 6vw, 60px);
+  justify-items: center;
+}
+
+.advantages__header {
+  display: grid;
+  gap: clamp(12px, 2.8vw, 22px);
+  max-width: min(720px, 92vw);
+  text-align: center;
+}
+
+.advantages__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-size: 0.78rem;
+  letter-spacing: 0.56em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.58);
+  padding: 6px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(10, 12, 16, 0.55);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+.advantages__title {
+  font-size: clamp(2.2rem, 5vw, 3.6rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--text-primary);
+  text-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+}
+
+.advantages__subtitle {
+  font-size: clamp(1rem, 1.6vw, 1.24rem);
+  color: var(--text-secondary);
+  line-height: 1.65;
 }
 
 .dial {
   position: relative;
-  background: linear-gradient(145deg, var(--panel-bg), #0a0c0f 70%);
-  padding: clamp(36px, 5.5vw, 64px) clamp(28px, 6vw, 72px);
-  border-radius: clamp(50px, 12vw, 170px);
-  box-shadow: 0 40px 90px var(--panel-shadow), inset 0 0 0 1px var(--panel-stroke);
+  width: 100%;
+  background: linear-gradient(150deg, rgba(14, 16, 20, 0.92), rgba(6, 7, 9, 0.92) 58%, rgba(20, 22, 28, 0.9));
+  padding: clamp(44px, 6.5vw, 82px) clamp(36px, 7vw, 90px);
+  border-radius: clamp(54px, 12vw, 160px);
+  box-shadow: 0 48px 110px rgba(0, 0, 0, 0.55), inset 0 0 0 1px var(--panel-stroke);
   overflow: hidden;
   isolation: isolate;
 }
@@ -49,24 +127,75 @@ body {
 .dial::before {
   content: "";
   position: absolute;
-  inset: clamp(18px, 2.6vw, 34px);
-  border-radius: clamp(38px, 10vw, 130px);
-  background: radial-gradient(ellipse at 60% 20%, rgba(255, 0, 50, 0.12), transparent 70%),
-    radial-gradient(ellipse at 30% 80%, rgba(255, 0, 50, 0.1), transparent 70%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(0, 0, 0, 0.5));
+  inset: clamp(22px, 3vw, 38px);
+  border-radius: clamp(40px, 11vw, 140px);
+  background: radial-gradient(ellipse at 68% 24%, rgba(255, 0, 50, 0.22), transparent 68%),
+    radial-gradient(ellipse at 32% 82%, rgba(255, 0, 50, 0.16), transparent 72%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(0, 0, 0, 0.55));
+  opacity: 0.92;
   z-index: 0;
-  opacity: 0.85;
 }
 
 .dial::after {
   content: "";
   position: absolute;
-  inset: clamp(32px, 5vw, 56px);
-  border-radius: clamp(30px, 9vw, 120px);
-  background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.04), transparent 65%),
-    radial-gradient(circle at 50% 80%, rgba(255, 0, 50, 0.12), transparent 65%);
+  inset: clamp(40px, 5.5vw, 60px);
+  border-radius: clamp(34px, 10vw, 130px);
+  background: radial-gradient(circle at 50% 18%, rgba(255, 255, 255, 0.07), transparent 60%),
+    radial-gradient(circle at 50% 82%, rgba(255, 0, 50, 0.18), transparent 70%);
+  opacity: 0.82;
   z-index: 0;
-  opacity: 0.75;
+}
+
+.dial__halo {
+  position: absolute;
+  inset: clamp(56px, 8vw, 96px);
+  border-radius: clamp(46px, 11vw, 140px);
+  background: radial-gradient(circle, rgba(255, 0, 50, 0.3) 0%, rgba(255, 0, 50, 0.12) 44%, transparent 70%);
+  opacity: 0;
+  filter: blur(12px);
+  transition: opacity 0.6s ease;
+  z-index: 1;
+}
+
+body.is-ready .dial__halo {
+  opacity: 0.35;
+}
+
+body[data-gear]:not([data-gear=""]) .dial__halo {
+  opacity: 0.68;
+}
+
+body.is-finished .dial__halo {
+  opacity: 0.28;
+}
+
+.dial__kanji {
+  position: absolute;
+  top: clamp(58px, 8vw, 102px);
+  left: clamp(44px, 8vw, 96px);
+  font-size: clamp(1.4rem, 2.8vw, 2.6rem);
+  letter-spacing: 0.48em;
+  writing-mode: vertical-rl;
+  color: rgba(255, 255, 255, 0.08);
+  text-shadow: 0 0 32px rgba(255, 0, 50, 0.28);
+  transform: translateY(12px);
+  opacity: 0;
+  transition: opacity 0.7s ease, transform 0.8s cubic-bezier(0.22, 0.87, 0.36, 1);
+  z-index: 2;
+}
+
+body.is-ready .dial__kanji {
+  opacity: 0.26;
+  transform: translateY(0);
+}
+
+body[data-gear]:not([data-gear=""]) .dial__kanji {
+  color: rgba(255, 255, 255, 0.18);
+}
+
+body.is-finished .dial__kanji {
+  opacity: 0.18;
 }
 
 .dial__frame {
@@ -79,15 +208,48 @@ body {
   pointer-events: none;
 }
 
-.dial__gear-indicator {
+.dial__crest {
   position: absolute;
-  top: clamp(36px, 6vw, 82px);
-  left: 50%;
-  transform: translate(-50%, -10px);
+  top: clamp(48px, 7vw, 90px);
+  right: clamp(48px, 7vw, 96px);
   display: inline-flex;
   align-items: center;
-  gap: 12px;
-  padding: 8px 20px;
+  gap: 10px;
+  padding: 10px 20px;
+  border-radius: 999px;
+  background: rgba(10, 12, 16, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.58);
+  letter-spacing: 0.38em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  z-index: 3;
+  box-shadow: 0 20px 46px rgba(0, 0, 0, 0.5);
+}
+
+.dial__crest-arrow {
+  color: rgba(255, 0, 50, 0.64);
+  font-size: 0.9rem;
+}
+
+body[data-gear]:not([data-gear=""]) .dial__crest {
+  border-color: rgba(255, 0, 50, 0.32);
+  color: rgba(255, 255, 255, 0.76);
+  box-shadow: 0 24px 48px rgba(255, 0, 50, 0.18);
+}
+
+.dial__gear-indicator {
+  position: absolute;
+  top: clamp(42px, 6.4vw, 86px);
+  left: 50%;
+  transform: translate(-50%, -12px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  column-gap: 14px;
+  row-gap: 6px;
+  padding: 10px 24px;
   border-radius: 999px;
   background: rgba(10, 11, 14, 0.72);
   border: 1px solid rgba(255, 0, 50, 0.28);
@@ -96,10 +258,10 @@ body {
   letter-spacing: 0.32em;
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.55);
-  z-index: 3;
+  z-index: 5;
   opacity: 0;
   transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
-    background 0.3s ease, border-color 0.3s ease;
+    background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .dial__gear-label {
@@ -112,6 +274,15 @@ body {
   font-size: 1.1rem;
   color: rgba(255, 255, 255, 0.65);
   min-width: 2ch;
+  text-align: center;
+}
+
+.dial__gear-mode {
+  font-size: 0.74rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.45);
+  min-width: 10ch;
   text-align: center;
 }
 
@@ -131,13 +302,72 @@ body[data-gear]:not([data-gear=""]) .dial__gear-value {
   color: #ffffff;
 }
 
+body[data-gear]:not([data-gear=""]) .dial__gear-mode {
+  color: rgba(255, 255, 255, 0.78);
+}
+
 body.is-finished .dial__gear-indicator {
   opacity: 0;
-  transform: translate(-50%, -12px);
+  transform: translate(-50%, -14px);
+}
+
+.dial__needle {
+  position: absolute;
+  top: 52%;
+  left: 50%;
+  width: clamp(18px, 2.4vw, 22px);
+  height: clamp(240px, 42vw, 360px);
+  transform: translate(-50%, -86%) rotate(var(--needle-angle, -128deg));
+  transform-origin: 50% 88%;
+  z-index: 2;
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.9s cubic-bezier(0.22, 0.87, 0.36, 1), opacity 0.6s ease;
+}
+
+.dial__needle::before {
+  content: "";
+  position: absolute;
+  bottom: 18%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: clamp(16px, 2.6vw, 20px);
+  height: 70%;
+  background: linear-gradient(180deg, rgba(255, 118, 140, 0.95), rgba(255, 0, 50, 0.92));
+  clip-path: polygon(50% 0, 64% 18%, 56% 100%, 44% 100%, 36% 18%);
+  box-shadow: 0 -18px 40px rgba(255, 0, 50, 0.45), 0 24px 60px rgba(0, 0, 0, 0.45);
+  border-radius: 999px;
+}
+
+.dial__needle::after {
+  content: "";
+  position: absolute;
+  bottom: 4%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: clamp(40px, 8vw, 72px);
+  height: clamp(40px, 8vw, 72px);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.18), rgba(14, 14, 18, 0.92));
+  border: 2px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.45);
+}
+
+body.is-ready .dial__needle {
+  opacity: 0.55;
+}
+
+body[data-gear]:not([data-gear=""]) .dial__needle {
+  opacity: 1;
+}
+
+body.is-finished .dial__needle {
+  opacity: 0.42;
 }
 
 .dial__accent {
   filter: drop-shadow(0 0 14px rgba(255, 0, 50, 0.45)) drop-shadow(0 0 44px rgba(255, 0, 50, 0.35));
+  z-index: 1;
 }
 
 .dial__mesh {
@@ -231,22 +461,22 @@ body.is-finished .dial__progress-fill {
 
 .metrics {
   position: relative;
-  z-index: 2;
+  z-index: 4;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: clamp(18px, 4vw, 46px);
-  padding: clamp(48px, 7vw, 72px) clamp(30px, 6vw, 68px) clamp(36px, 6vw, 60px);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(18px, 4.5vw, 44px);
+  padding: clamp(74px, 9vw, 110px) clamp(34px, 7vw, 90px) clamp(54px, 7vw, 84px);
 }
 
 .metrics::before {
   content: "";
   position: absolute;
-  inset: clamp(24px, 4vw, 40px) clamp(12px, 3vw, 30px);
-  border-radius: clamp(26px, 6vw, 60px);
-  background: linear-gradient(145deg, rgba(255, 0, 50, 0.12), rgba(10, 11, 14, 0.8));
-  border: 1px solid rgba(255, 255, 255, 0.04);
+  inset: clamp(34px, 5.8vw, 70px) clamp(18px, 4.4vw, 46px);
+  border-radius: clamp(30px, 8vw, 80px);
+  background: linear-gradient(145deg, rgba(255, 0, 50, 0.16), rgba(8, 10, 14, 0.82));
+  border: 1px solid rgba(255, 255, 255, 0.06);
   filter: blur(0.5px);
-  opacity: 0.6;
+  opacity: 0.72;
   z-index: -1;
 }
 
@@ -254,17 +484,18 @@ body.is-finished .dial__progress-fill {
   position: relative;
   display: grid;
   justify-items: center;
-  gap: clamp(10px, 2vw, 18px);
-  padding: clamp(20px, 3vw, 28px) clamp(16px, 3vw, 24px) clamp(28px, 4vw, 34px);
-  border-radius: clamp(24px, 5vw, 42px);
-  background: linear-gradient(160deg, rgba(20, 22, 26, 0.85), rgba(7, 8, 10, 0.7));
+  gap: clamp(12px, 2vw, 20px);
+  padding: clamp(24px, 4.5vw, 36px) clamp(20px, 4vw, 30px) clamp(32px, 5vw, 44px);
+  border-radius: clamp(26px, 6vw, 48px);
+  background: linear-gradient(160deg, rgba(20, 22, 26, 0.82), rgba(7, 8, 10, 0.7));
   border: 1px solid rgba(255, 255, 255, 0.05);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-  opacity: 0.25;
-  transform: translateY(24px) scale(0.96);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+  opacity: 0.2;
+  transform: translateY(28px) scale(0.95);
   transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
     filter 0.6s ease;
   font-variant-numeric: tabular-nums;
+  text-align: center;
 }
 
 .metric::before {
@@ -298,6 +529,7 @@ body.is-finished .dial__progress-fill {
   color: var(--text-secondary);
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 10px;
   letter-spacing: 0.03em;
 }
@@ -337,6 +569,16 @@ body.is-finished .dial__progress-fill {
   letter-spacing: 0.08em;
 }
 
+.metric__description {
+  font-size: clamp(0.9rem, 1.3vw, 1rem);
+  color: rgba(255, 255, 255, 0.62);
+  line-height: 1.6;
+  max-width: 28ch;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1);
+}
+
 .metric--active {
   opacity: 1;
   transform: translateY(0) scale(1.02);
@@ -357,8 +599,14 @@ body.is-finished .dial__progress-fill {
   color: rgba(255, 255, 255, 0.82);
 }
 
+.metric--active .metric__description,
+.metric--complete .metric__description {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 .metric--complete {
-  opacity: 0.92;
+  opacity: 0.95;
   transform: translateY(0) scale(1);
   filter: drop-shadow(0 16px 32px rgba(0, 0, 0, 0.35));
 }
@@ -377,12 +625,22 @@ body.no-js .metric::before,
 body.no-js .metric__badge,
 body.no-js .dial__progress-fill,
 body.no-js .dial__corner,
-body.no-js .dial__pulse {
+body.no-js .dial__pulse,
+body.no-js .dial__needle {
   animation: none;
   transition: none;
 }
 
 body.no-js .metric {
+  opacity: 1;
+  transform: none;
+}
+
+body.no-js .metric::before {
+  opacity: 1;
+}
+
+body.no-js .metric__description {
   opacity: 1;
   transform: none;
 }
@@ -396,14 +654,46 @@ body.no-js .dial__gear-indicator {
   display: none;
 }
 
-@media (max-width: 840px) {
-  .metrics {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    padding: clamp(40px, 6vw, 64px) clamp(18px, 5vw, 44px) clamp(28px, 6vw, 54px);
+body.no-js .dial__halo {
+  opacity: 0.5;
+}
+
+body.no-js .dial__kanji {
+  opacity: 0.28;
+  transform: translateY(0);
+}
+
+body.no-js .dial__needle {
+  opacity: 0.48;
+}
+
+@media (min-width: 940px) {
+  .advantages {
+    justify-items: stretch;
   }
 
-  .metrics::before {
-    inset: clamp(18px, 4vw, 34px) clamp(12px, 3vw, 28px);
+  .advantages__header {
+    text-align: left;
+    justify-self: start;
+  }
+}
+
+@media (max-width: 760px) {
+  body {
+    padding: clamp(36px, 10vh, 80px) clamp(18px, 6vw, 40px);
+  }
+
+  .advantages__eyebrow {
+    letter-spacing: 0.42em;
+  }
+
+  .dial__gear-indicator {
+    padding: 8px 18px;
+    column-gap: 10px;
+  }
+
+  .dial__gear-mode {
+    min-width: 0;
   }
 }
 
@@ -411,10 +701,50 @@ body.no-js .dial__gear-indicator {
   .metrics {
     grid-template-columns: 1fr;
     gap: 28px;
+    padding: clamp(58px, 10vw, 84px) clamp(22px, 7vw, 44px) clamp(44px, 9vw, 70px);
+  }
+
+  .metrics::before {
+    inset: clamp(26px, 7vw, 48px) clamp(16px, 6vw, 32px);
   }
 
   .metric {
     padding: clamp(24px, 6vw, 34px);
+  }
+
+  .metric__description {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .advantages__title {
+    font-size: clamp(1.9rem, 9vw, 2.8rem);
+  }
+
+  .dial__crest {
+    top: clamp(38px, 8vw, 76px);
+    right: clamp(32px, 8vw, 70px);
+    padding: 8px 16px;
+    letter-spacing: 0.32em;
+  }
+
+  .dial__gear-indicator {
+    row-gap: 4px;
+  }
+}
+
+@media (max-width: 420px) {
+  .advantages__eyebrow {
+    letter-spacing: 0.32em;
+  }
+
+  .dial {
+    border-radius: clamp(40px, 16vw, 100px);
+  }
+
+  .dial__gear-indicator {
+    letter-spacing: 0.22em;
   }
 }
 


### PR DESCRIPTION
## Summary
- redesign the advantages block with a Japanese-inspired gauge, hero copy, and four sequential metrics for wholesale auto parts partners
- implement the animation sequence that shifts between gears, formats the KPIs, and drives the speedometer needle
- refresh the styling with neon gradients, adaptive layout, and graceful degradation for no-JS users

## Testing
- manual visual QA in browser

------
https://chatgpt.com/codex/tasks/task_e_68cc964d66e08321adacfcc5b62ff114