### PR TITLE
Create neon GSAP speedometer dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,239 +3,263 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Скорость подключения</title>
+    <title>Неоновый спидометр</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700&family=Manrope:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
   </head>
-  <body class="no-js">
-    <main class="dashboard">
-      <div class="dial">
-        <svg class="dial__frame" viewBox="0 0 900 360" aria-hidden="true">
-          <defs>
-            <linearGradient id="dial-outline-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-              <stop offset="0%" stop-color="#ff4d6c" />
-              <stop offset="42%" stop-color="#ff0032" />
-              <stop offset="100%" stop-color="#ff4d6c" />
-            </linearGradient>
-            <linearGradient id="dial-inner-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
-              <stop offset="0%" stop-color="rgba(255, 0, 50, 0.45)" />
-              <stop offset="35%" stop-color="rgba(255, 0, 50, 0.3)" />
-              <stop offset="100%" stop-color="rgba(255, 0, 50, 0.05)" />
-            </linearGradient>
-            <pattern id="dial-grid" patternUnits="userSpaceOnUse" width="44" height="44">
-              <rect class="dial__grid-bar dial__grid-bar--major" x="0" y="0" width="3" height="44"></rect>
-              <rect class="dial__grid-bar dial__grid-bar--minor" x="10" y="0" width="2" height="44"></rect>
-              <rect class="dial__grid-bar dial__grid-bar--major" x="22" y="0" width="3" height="44"></rect>
-              <rect class="dial__grid-bar dial__grid-bar--minor" x="32" y="0" width="2" height="44"></rect>
-            </pattern>
-            <mask id="dial-ring-mask" maskUnits="userSpaceOnUse">
-              <rect x="0" y="0" width="900" height="360" fill="black"></rect>
-              <rect x="42" y="50" width="816" height="260" rx="88" ry="88" fill="white"></rect>
-              <rect x="74" y="82" width="752" height="196" rx="62" ry="62" fill="black"></rect>
-            </mask>
-          </defs>
-          <g class="dial__progress">
-            <rect
-              class="dial__progress-track"
-              x="24"
-              y="32"
-              width="852"
-              height="296"
-              rx="110"
-              ry="110"
-              pathLength="100"
-            ></rect>
-            <rect
-              class="dial__progress-fill"
-              x="24"
-              y="32"
-              width="852"
-              height="296"
-              rx="110"
-              ry="110"
-              pathLength="100"
-            ></rect>
-          </g>
-          <g class="dial__accent">
-            <rect class="dial__mesh" x="0" y="0" width="900" height="360" mask="url(#dial-ring-mask)"></rect>
-            <rect
-              class="dial__pulse"
-              x="48"
-              y="56"
-              width="804"
-              height="248"
-              rx="76"
-              ry="76"
-              pathLength="100"
-            ></rect>
-            <rect
-              class="dial__outline"
-              x="42"
-              y="50"
-              width="816"
-              height="260"
-              rx="88"
-              ry="88"
-              pathLength="100"
-            ></rect>
-            <rect
-              class="dial__inner"
-              x="66"
-              y="74"
-              width="768"
-              height="212"
-              rx="64"
-              ry="64"
-              pathLength="100"
-            ></rect>
-            <g class="dial__corner-sparks">
-              <path class="dial__corner" d="M96 104h74"></path>
-              <path class="dial__corner" d="M96 104v74"></path>
-              <path class="dial__corner" d="M804 104h-74"></path>
-              <path class="dial__corner" d="M804 104v74"></path>
-              <path class="dial__corner" d="M96 256h74"></path>
-              <path class="dial__corner" d="M96 256v-74"></path>
-              <path class="dial__corner" d="M804 256h-74"></path>
-              <path class="dial__corner" d="M804 256v-74"></path>
+  <body>
+    <canvas id="glow-canvas" aria-hidden="true"></canvas>
+    <main class="speedometer">
+      <section class="speedometer__panel" aria-labelledby="speed-title">
+        <header class="speedometer__header">
+          <span class="speedometer__chip">HyperDrive AI</span>
+          <h1 id="speed-title" class="speedometer__title">Кибер-спидометр</h1>
+          <p class="speedometer__subtitle">
+            Реактивный монитор скорости с неоновой дугой, стеклянной глубиной и живыми эффектами.
+          </p>
+        </header>
+        <div class="speedometer__display">
+          <svg
+            class="speedometer__svg"
+            viewBox="0 0 420 420"
+            role="img"
+            aria-labelledby="speed-title"
+          >
+            <defs>
+              <linearGradient id="speedometer-track" x1="0%" y1="0%" x2="100%" y2="0%">
+                <stop offset="0%" stop-color="#f2f5ff" stop-opacity="0.12" />
+                <stop offset="45%" stop-color="#f4f7ff" stop-opacity="0.32" />
+                <stop offset="100%" stop-color="#ffffff" stop-opacity="0.08" />
+              </linearGradient>
+              <linearGradient id="speedometer-progress" x1="0%" y1="0%" x2="100%" y2="0%">
+                <stop offset="0%" stop-color="#ff9a9e" />
+                <stop offset="38%" stop-color="#ff0037" />
+                <stop offset="68%" stop-color="#ff0730" />
+                <stop offset="100%" stop-color="#ff8f8f" />
+              </linearGradient>
+              <radialGradient id="speedometer-glow" cx="50%" cy="50%" r="50%">
+                <stop offset="0%" stop-color="rgba(255, 255, 255, 0.9)" />
+                <stop offset="60%" stop-color="rgba(255, 0, 70, 0.55)" />
+                <stop offset="100%" stop-color="rgba(0, 0, 0, 0)" />
+              </radialGradient>
+              <filter id="glow-filter" x="-60%" y="-60%" width="220%" height="220%">
+                <feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur" />
+                <feMerge>
+                  <feMergeNode in="blur" />
+                  <feMergeNode in="SourceGraphic" />
+                </feMerge>
+              </filter>
+              <filter id="soft-shadow" x="-40%" y="-40%" width="180%" height="180%">
+                <feDropShadow dx="0" dy="8" stdDeviation="16" flood-color="rgba(0, 0, 0, 0.25)" />
+              </filter>
+              <linearGradient id="indicator-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+                <stop offset="0%" stop-color="#ffdde1" />
+                <stop offset="100%" stop-color="#ff0032" />
+              </linearGradient>
+            </defs>
+            <g class="speedometer__rings" filter="url(#soft-shadow)">
+              <circle cx="210" cy="210" r="186" fill="rgba(255, 255, 255, 0.06)" opacity="0.5"></circle>
+              <circle cx="210" cy="210" r="160" fill="rgba(255, 255, 255, 0.08)" opacity="0.6"></circle>
+              <circle cx="210" cy="210" r="120" fill="url(#speedometer-glow)" opacity="0.35"></circle>
             </g>
-          </g>
-        </svg>
-        <div class="dial__gear-indicator" aria-hidden="true">
-          <span class="dial__gear-label">Передача</span>
-          <span class="dial__gear-value">—</span>
+            <path
+              id="speedometer-arc-track"
+              class="speedometer__arc"
+              d="M80 320A170 170 0 0 1 340 320"
+              stroke="url(#speedometer-track)"
+              stroke-width="24"
+              stroke-linecap="round"
+              fill="none"
+              opacity="0.75"
+            ></path>
+            <path
+              id="speedometer-arc-progress"
+              class="speedometer__arc speedometer__arc--progress"
+              d="M80 320A170 170 0 0 1 340 320"
+              stroke="url(#speedometer-progress)"
+              stroke-width="28"
+              stroke-linecap="round"
+              fill="none"
+              filter="url(#glow-filter)"
+              data-role="progress"
+            ></path>
+            <path
+              id="speedometer-arc-glass"
+              d="M78 320A172 172 0 0 1 342 320"
+              stroke="rgba(255, 255, 255, 0.45)"
+              stroke-width="8"
+              stroke-linecap="round"
+              fill="none"
+              opacity="0.35"
+            ></path>
+            <g class="speedometer__ticks" stroke="rgba(25, 25, 30, 0.42)" stroke-width="2">
+              <g transform="translate(210 210)">
+                <!-- Major ticks -->
+                <g id="major-ticks" data-role="ticks"></g>
+              </g>
+            </g>
+            <g class="speedometer__needle" data-role="needle" transform="translate(210 210)">
+              <circle class="speedometer__needle-core" r="14" fill="rgba(255, 255, 255, 0.8)" />
+              <circle class="speedometer__needle-glow" r="32" fill="rgba(255, 0, 55, 0.22)" />
+              <polygon
+                points="0,-18 6,-6 70,-8 78,0 70,8 6,6 0,18 -8,6 -72,12 -80,0 -72,-12 -8,-6"
+                fill="url(#indicator-gradient)"
+                opacity="0.95"
+                filter="url(#glow-filter)"
+              ></polygon>
+            </g>
+            <circle cx="210" cy="210" r="102" fill="rgba(255, 255, 255, 0.12)" stroke="rgba(255, 255, 255, 0.25)" stroke-width="2"></circle>
+            <circle cx="210" cy="210" r="92" fill="rgba(255, 255, 255, 0.08)"></circle>
+            <text x="210" y="204" text-anchor="middle" class="speedometer__value" data-role="speed-value">0</text>
+            <text x="210" y="236" text-anchor="middle" class="speedometer__unit">км/ч</text>
+            <text x="210" y="280" text-anchor="middle" class="speedometer__status" data-role="status">Система готова</text>
+            <g class="speedometer__meta">
+              <text x="120" y="148" class="speedometer__meta-label">режим</text>
+              <text x="120" y="166" class="speedometer__meta-value" data-role="mode">SYNC</text>
+              <text x="300" y="148" class="speedometer__meta-label">турбо</text>
+              <text x="300" y="166" class="speedometer__meta-value" data-role="boost">0.0g</text>
+            </g>
+          </svg>
         </div>
-        <div class="metrics">
-          <div class="metric" data-gear="I" data-value="27.18" data-decimals="2" data-duration="1400">
-            <div class="metric__badge" aria-hidden="true">I</div>
-            <div class="metric__title">
-              Входящая
-              <span class="metric__hint" aria-hidden="true">i</span>
-            </div>
-            <div class="metric__value">
-              <span class="metric__value-number">0</span>
-            </div>
-            <div class="metric__unit">Мбит/с</div>
-          </div>
-          <div class="metric" data-gear="II" data-value="30.28" data-decimals="2" data-duration="1200">
-            <div class="metric__badge" aria-hidden="true">II</div>
-            <div class="metric__title">
-              Исходящая
-              <span class="metric__hint" aria-hidden="true">i</span>
-            </div>
-            <div class="metric__value">
-              <span class="metric__value-number">0</span>
-            </div>
-            <div class="metric__unit">Мбит/с</div>
-          </div>
-          <div class="metric" data-gear="III" data-value="32" data-decimals="0" data-duration="1500">
-            <div class="metric__badge" aria-hidden="true">III</div>
-            <div class="metric__title">
-              Задержка
-              <span class="metric__hint" aria-hidden="true">i</span>
-            </div>
-            <div class="metric__value">
-              <span class="metric__value-number">0</span>
-            </div>
-            <div class="metric__unit">мс</div>
-          </div>
-        </div>
-      </div>
+      </section>
     </main>
-    <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        const body = document.body;
-        body.classList.remove('no-js');
-        const metrics = Array.from(document.querySelectorAll('.metric'));
-        const gearValue = document.querySelector('.dial__gear-value');
-        if (gearValue) {
-          gearValue.textContent = '—';
-        }
-        const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        const bootDelay = reduceMotion ? 0 : 240;
-        const betweenShift = reduceMotion ? 0 : 260;
-        const coolDown = reduceMotion ? 0 : 320;
-        if (!metrics.length) {
-          body.classList.add('is-ready');
-          return;
-        }
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r155/three.min.js" integrity="sha512-MyH7Q/b5i6ub5wHCfi3CXRDobaWHmA6/nvDPONKOfFUK79l3zuxM59kMAoRnzhwOTCQKtZ3e/TISBg8ailqXFQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha512-9G0mKCNt2uQ6Xo8XOSY67ymNEzbGDbVS9/6IKxhpcJn/abNqxabWWMwBLT/gRghOAqxCLv7saEh1PQuIrAjf/Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script type="module">
+      const canvas = document.getElementById('glow-canvas');
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+      const renderer = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      renderer.setSize(window.innerWidth, window.innerHeight);
 
-        const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-        const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
-
-        const animateValue = (element, target, decimals, duration) => {
-          return new Promise((resolve) => {
-            const effectiveDuration = reduceMotion ? 0 : duration;
-            const start = performance.now();
-            const startValue = 0;
-
-            const format = (value) => {
-              if (decimals > 0) {
-                return value.toFixed(decimals);
-              }
-              return Math.round(value).toString();
-            };
-
-            if (effectiveDuration === 0) {
-              element.textContent = format(target);
-              resolve();
-              return;
-            }
-
-            const update = (now) => {
-              const progress = Math.min((now - start) / effectiveDuration, 1);
-              const eased = easeOutCubic(progress);
-              const current = startValue + (target - startValue) * eased;
-              element.textContent = format(current);
-
-              if (progress < 1) {
-                requestAnimationFrame(update);
-              } else {
-                element.textContent = format(target);
-                resolve();
-              }
-            };
-
-            requestAnimationFrame(update);
-          });
-        };
-
-        const startSequence = async () => {
-          body.classList.add('is-ready');
-          await wait(bootDelay);
-
-          for (const metric of metrics) {
-            const valueEl = metric.querySelector('.metric__value-number');
-            const target = Number(metric.dataset.value);
-            const decimals = Number(metric.dataset.decimals || 0);
-            const duration = Number(metric.dataset.duration || 1200);
-            const gear = metric.dataset.gear || '';
-
-            body.dataset.gear = gear;
-            if (gearValue) {
-              gearValue.textContent = gear || '—';
-            }
-            metric.classList.add('metric--active');
-            await animateValue(valueEl, target, decimals, duration);
-            metric.classList.remove('metric--active');
-            metric.classList.add('metric--complete');
-            await wait(betweenShift);
-          }
-
-          await wait(coolDown);
-          body.dataset.gear = '';
-          if (gearValue) {
-            gearValue.textContent = '—';
-          }
-          body.classList.add('is-finished');
-        };
-
-        startSequence();
+      const ringGeometry = new THREE.TorusGeometry(2.6, 0.12, 32, 220);
+      const ringMaterial = new THREE.MeshBasicMaterial({
+        color: 0xff1744,
+        transparent: true,
+        opacity: 0.6,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
       });
+      const ring = new THREE.Mesh(ringGeometry, ringMaterial);
+      scene.add(ring);
+
+      const haloGeometry = new THREE.TorusGeometry(2.6, 0.32, 16, 120);
+      const haloMaterial = new THREE.MeshBasicMaterial({
+        color: 0xff99aa,
+        transparent: true,
+        opacity: 0.18,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      });
+      const halo = new THREE.Mesh(haloGeometry, haloMaterial);
+      scene.add(halo);
+
+      camera.position.set(0, 0, 6);
+      const animateBackground = () => {
+        ring.rotation.x += 0.002;
+        ring.rotation.y += 0.0016;
+        halo.rotation.x -= 0.0012;
+        halo.rotation.y += 0.0014;
+        renderer.render(scene, camera);
+        requestAnimationFrame(animateBackground);
+      };
+      animateBackground();
+
+      const speedPath = document.querySelector('[data-role="progress"]');
+      const needle = document.querySelector('[data-role="needle"]');
+      const speedValue = document.querySelector('[data-role="speed-value"]');
+      const status = document.querySelector('[data-role="status"]');
+      const modeValue = document.querySelector('[data-role="mode"]');
+      const boostValue = document.querySelector('[data-role="boost"]');
+      const ticksGroup = document.querySelector('[data-role="ticks"]');
+
+      const maxSpeed = 240;
+      const arcLength = speedPath.getTotalLength();
+      speedPath.style.strokeDasharray = arcLength.toString();
+      speedPath.style.strokeDashoffset = arcLength.toString();
+
+      const createTicks = () => {
+        const majorTickCount = 7;
+        const startAngle = -210; // degrees
+        const endAngle = 30;
+        for (let i = 0; i < majorTickCount; i += 1) {
+          const angle = THREE.MathUtils.degToRad(startAngle + (i / (majorTickCount - 1)) * (endAngle - startAngle));
+          const inner = new THREE.Vector2(Math.cos(angle) * 140, Math.sin(angle) * 140);
+          const outer = new THREE.Vector2(Math.cos(angle) * 170, Math.sin(angle) * 170);
+          const tick = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+          tick.setAttribute('x1', inner.x.toFixed(2));
+          tick.setAttribute('y1', inner.y.toFixed(2));
+          tick.setAttribute('x2', outer.x.toFixed(2));
+          tick.setAttribute('y2', outer.y.toFixed(2));
+          tick.setAttribute('stroke-width', i % 2 === 0 ? '3.4' : '2.2');
+          tick.setAttribute('stroke', i % 2 === 0 ? 'rgba(15, 15, 22, 0.66)' : 'rgba(20, 20, 30, 0.45)');
+          tick.setAttribute('opacity', i % 2 === 0 ? '0.9' : '0.7');
+          ticksGroup.appendChild(tick);
+        }
+      };
+      createTicks();
+
+      const neonPulse = gsap.timeline({ repeat: -1, defaults: { ease: 'sine.inOut' } });
+      neonPulse
+        .to('[data-role="progress"]', { strokeWidth: 32, duration: 1.6, yoyo: true, repeat: 1 }, 0)
+        .to(
+          '.speedometer__needle-glow',
+          { scale: 1.14, transformOrigin: '50% 50%', opacity: 0.42, duration: 1.2, yoyo: true, repeat: 1 },
+          0
+        );
+
+      const speedObj = { value: 0 };
+
+      const updateSpeed = () => {
+        const progress = speedObj.value / maxSpeed;
+        const clamped = Math.min(Math.max(progress, 0), 1);
+        const dashOffset = arcLength - arcLength * clamped;
+        speedPath.style.strokeDashoffset = dashOffset.toString();
+        const rotation = gsap.utils.mapRange(0, 1, -210, 30, clamped);
+        gsap.set(needle, { rotation, transformOrigin: '50% 50%' });
+        speedValue.textContent = Math.round(speedObj.value).toString().padStart(3, '0');
+        boostValue.textContent = `${(0.1 + clamped * 1.9).toFixed(2)}g`;
+      };
+
+      const master = gsap.timeline({ repeat: -1, repeatDelay: 1.5 });
+      master
+        .set(status, { textContent: 'Инициализация', opacity: 0.65 })
+        .set(modeValue, { textContent: 'SYNC' })
+        .to(speedObj, { value: 90, duration: 1.6, ease: 'power2.out', onUpdate: updateSpeed })
+        .to(status, { textContent: 'Разгон', duration: 0.2 }, '<')
+        .to(modeValue, { textContent: 'BOOST' }, '<0.6')
+        .to(speedObj, { value: maxSpeed, duration: 2.8, ease: 'power3.inOut', onUpdate: updateSpeed })
+        .to(status, { textContent: 'Критический пик', duration: 0.2 }, '-=1')
+        .to('.speedometer__panel', { '--glow-intensity': 0.85, duration: 0.6, ease: 'sine.in' }, '-=1.6')
+        .to(speedObj, { value: 128, duration: 2.4, ease: 'power3.out', onUpdate: updateSpeed })
+        .to(status, { textContent: 'Стабилизация', duration: 0.2 }, '-=1.6')
+        .to(modeValue, { textContent: 'SYNC' }, '-=1.2')
+        .to('.speedometer__panel', { '--glow-intensity': 0.25, duration: 1.2, ease: 'sine.out' }, '-=1.2')
+        .to(speedObj, { value: 0, duration: 1.6, ease: 'expo.out', onUpdate: updateSpeed })
+        .to(status, { textContent: 'Реинициализация', duration: 0.2 }, '-=1');
+
+      gsap.to('.speedometer__panel', {
+        '--glow-intensity': 0.32,
+        duration: 1.4,
+        ease: 'power2.out',
+        yoyo: true,
+        repeat: -1,
+      });
+
+      const resize = () => {
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        camera.aspect = window.innerWidth / window.innerHeight;
+        camera.updateProjectionMatrix();
+      };
+      window.addEventListener('resize', resize);
+
+      updateSpeed();
     </script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,19 @@
 :root {
-  color-scheme: dark;
-  font-family: "Manrope", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  --bg: #101214;
-  --panel-bg: #14161a;
-  --panel-shadow: rgba(0, 0, 0, 0.55);
-  --panel-inner: #0d0e10;
-  --panel-stroke: rgba(255, 255, 255, 0.06);
-  --accent: #ff0032;
-  --accent-strong: #ff2247;
-  --accent-soft: rgba(255, 0, 50, 0.55);
-  --accent-glow: rgba(255, 0, 50, 0.32);
-  --text-primary: #ffffff;
-  --text-secondary: #c5c8ce;
-  --text-tertiary: rgba(255, 255, 255, 0.64);
+  font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color-scheme: light;
+  --bg-start: #f4f7fb;
+  --bg-end: #dfe4f5;
+  --panel-surface: rgba(255, 255, 255, 0.58);
+  --panel-outline: rgba(255, 255, 255, 0.9);
+  --panel-highlight: rgba(255, 255, 255, 0.45);
+  --panel-shadow: rgba(70, 80, 120, 0.28);
+  --text-primary: #161827;
+  --text-secondary: rgba(22, 24, 39, 0.7);
+  --text-tertiary: rgba(22, 24, 39, 0.48);
+  --accent-strong: #ff0032;
+  --accent-soft: rgba(255, 0, 70, 0.28);
+  --glass-border: rgba(255, 255, 255, 0.55);
+  --glass-blur: 24px;
 }
 
 * {
@@ -21,442 +22,210 @@
   padding: 0;
 }
 
+html,
 body {
-  min-height: 100vh;
+  min-height: 100%;
+}
+
+body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: radial-gradient(circle at 20% 20%, #181a1f 0%, #08090b 65%, #040506 100%);
+  background: radial-gradient(circle at 10% 20%, #ffffff 0%, var(--bg-start) 42%, var(--bg-end) 100%);
   color: var(--text-primary);
-  letter-spacing: 0.01em;
-  -webkit-font-smoothing: antialiased;
-}
-
-.dashboard {
-  width: min(940px, 94vw);
-}
-
-.dial {
+  overflow: hidden;
+  font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   position: relative;
-  background: linear-gradient(145deg, var(--panel-bg), #0a0c0f 70%);
-  padding: clamp(36px, 5.5vw, 64px) clamp(28px, 6vw, 72px);
-  border-radius: clamp(50px, 12vw, 170px);
-  box-shadow: 0 40px 90px var(--panel-shadow), inset 0 0 0 1px var(--panel-stroke);
+}
+
+#glow-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 0;
+  mix-blend-mode: screen;
+  pointer-events: none;
+  opacity: 0.85;
+}
+
+.speedometer {
+  position: relative;
+  z-index: 1;
+  width: min(640px, 90vw);
+}
+
+.speedometer__panel {
+  position: relative;
+  padding: clamp(28px, 5.6vw, 46px);
+  border-radius: clamp(28px, 6vw, 44px);
+  background: var(--panel-surface);
+  border: 1px solid color-mix(in srgb, var(--panel-outline) 62%, transparent);
+  backdrop-filter: blur(var(--glass-blur)) saturate(140%);
+  box-shadow: 0 32px 90px var(--panel-shadow), inset 0 1px 0 var(--panel-outline), inset 0 -1px 0 rgba(255, 255, 255, 0.45);
   overflow: hidden;
   isolation: isolate;
+  transition: box-shadow 0.6s ease, border 0.6s ease;
+  --glow-intensity: 0.25;
 }
 
-.dial::before {
-  content: "";
+.speedometer__panel::before {
+  content: '';
   position: absolute;
-  inset: clamp(18px, 2.6vw, 34px);
-  border-radius: clamp(38px, 10vw, 130px);
-  background: radial-gradient(ellipse at 60% 20%, rgba(255, 0, 50, 0.12), transparent 70%),
-    radial-gradient(ellipse at 30% 80%, rgba(255, 0, 50, 0.1), transparent 70%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(0, 0, 0, 0.5));
-  z-index: 0;
-  opacity: 0.85;
-}
-
-.dial::after {
-  content: "";
-  position: absolute;
-  inset: clamp(32px, 5vw, 56px);
-  border-radius: clamp(30px, 9vw, 120px);
-  background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.04), transparent 65%),
-    radial-gradient(circle at 50% 80%, rgba(255, 0, 50, 0.12), transparent 65%);
-  z-index: 0;
-  opacity: 0.75;
-}
-
-.dial__frame {
-  position: absolute;
-  inset: clamp(12px, 2.2vw, 28px);
-  width: calc(100% - 2 * clamp(12px, 2.2vw, 28px));
-  height: calc(100% - 2 * clamp(12px, 2.2vw, 28px));
-  z-index: 1;
-  fill: none;
+  inset: 18px;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  opacity: 0.55;
   pointer-events: none;
 }
 
-.dial__gear-indicator {
+.speedometer__panel::after {
+  content: '';
   position: absolute;
-  top: clamp(36px, 6vw, 82px);
-  left: 50%;
-  transform: translate(-50%, -10px);
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 20px;
-  border-radius: 999px;
-  background: rgba(10, 11, 14, 0.72);
-  border: 1px solid rgba(255, 0, 50, 0.28);
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
-  font-size: 0.78rem;
-  letter-spacing: 0.32em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
-  z-index: 3;
-  opacity: 0;
-  transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
-    background 0.3s ease, border-color 0.3s ease;
+  inset: -20%;
+  background: radial-gradient(circle at 60% 25%, rgba(255, 255, 255, 0.45), transparent 58%),
+    radial-gradient(circle at 20% 80%, rgba(255, 0, 50, calc(var(--glow-intensity) * 0.4)), transparent 62%);
+  opacity: calc(0.35 + var(--glow-intensity) * 0.35);
+  filter: blur(82px);
+  pointer-events: none;
+  transition: opacity 0.6s ease;
 }
 
-.dial__gear-label {
-  font-size: 0.7rem;
-  letter-spacing: 0.42em;
-  color: rgba(255, 255, 255, 0.38);
-}
-
-.dial__gear-value {
-  font-size: 1.1rem;
-  color: rgba(255, 255, 255, 0.65);
-  min-width: 2ch;
+.speedometer__header {
   text-align: center;
-}
-
-body.is-ready .dial__gear-indicator {
-  opacity: 1;
-  transform: translate(-50%, 0);
-}
-
-body[data-gear]:not([data-gear=""]) .dial__gear-indicator {
-  background: rgba(255, 0, 50, 0.18);
-  border-color: rgba(255, 0, 50, 0.45);
-  box-shadow: 0 18px 44px rgba(255, 0, 50, 0.24);
-  color: rgba(255, 255, 255, 0.72);
-}
-
-body[data-gear]:not([data-gear=""]) .dial__gear-value {
-  color: #ffffff;
-}
-
-body.is-finished .dial__gear-indicator {
-  opacity: 0;
-  transform: translate(-50%, -12px);
-}
-
-.dial__accent {
-  filter: drop-shadow(0 0 14px rgba(255, 0, 50, 0.45)) drop-shadow(0 0 44px rgba(255, 0, 50, 0.35));
-}
-
-.dial__mesh {
-  fill: url(#dial-grid);
-  mix-blend-mode: screen;
-  opacity: 0.82;
-}
-
-.dial__grid-bar {
-  fill: rgba(255, 0, 50, 0.22);
-}
-
-.dial__grid-bar--major {
-  opacity: 0.85;
-}
-
-.dial__grid-bar--minor {
-  opacity: 0.55;
-}
-
-.dial__pulse {
-  fill: none;
-  stroke: rgba(255, 0, 50, 0.55);
-  stroke-width: 3;
-  stroke-dasharray: 2.5 14;
-  stroke-linecap: round;
-  stroke-dashoffset: 6;
-  animation: dial-pulse 2.4s linear infinite;
-}
-
-.dial__outline {
-  fill: none;
-  stroke: url(#dial-outline-gradient);
-  stroke-width: 3;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  opacity: 0.95;
-}
-
-.dial__inner {
-  fill: none;
-  stroke: url(#dial-inner-gradient);
-  stroke-width: 2;
-  opacity: 0.8;
-  stroke-dasharray: 14 10;
-  stroke-linecap: round;
-}
-
-.dial__corner-sparks {
-  fill: none;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.dial__corner {
-  stroke: rgba(255, 0, 50, 0.55);
-  stroke-width: 4;
-  stroke-dasharray: 18 22;
-  stroke-dashoffset: 14;
-  opacity: 0.75;
-  animation: dial-corner 3.2s ease-in-out infinite;
-}
-
-.dial__progress-track,
-.dial__progress-fill {
-  fill: none;
-  stroke-width: 6;
-  stroke-linecap: round;
-}
-
-.dial__progress-track {
-  stroke: rgba(255, 0, 50, 0.18);
-}
-
-.dial__progress-fill {
-  stroke: rgba(255, 0, 50, 0.65);
-  stroke-dasharray: 100;
-  stroke-dashoffset: 100;
-  opacity: 0;
-  filter: drop-shadow(0 0 20px var(--accent-glow));
-}
-
-body.is-ready .dial__progress-fill {
-  opacity: 1;
-  animation: dial-progress 3.4s cubic-bezier(0.21, 0.85, 0.32, 1) forwards;
-}
-
-body.is-finished .dial__progress-fill {
-  stroke: var(--accent);
-}
-
-.metrics {
+  margin-bottom: clamp(18px, 4vw, 32px);
   position: relative;
   z-index: 2;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: clamp(18px, 4vw, 46px);
-  padding: clamp(48px, 7vw, 72px) clamp(30px, 6vw, 68px) clamp(36px, 6vw, 60px);
 }
 
-.metrics::before {
-  content: "";
-  position: absolute;
-  inset: clamp(24px, 4vw, 40px) clamp(12px, 3vw, 30px);
-  border-radius: clamp(26px, 6vw, 60px);
-  background: linear-gradient(145deg, rgba(255, 0, 50, 0.12), rgba(10, 11, 14, 0.8));
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  filter: blur(0.5px);
-  opacity: 0.6;
-  z-index: -1;
-}
-
-.metric {
-  position: relative;
-  display: grid;
-  justify-items: center;
-  gap: clamp(10px, 2vw, 18px);
-  padding: clamp(20px, 3vw, 28px) clamp(16px, 3vw, 24px) clamp(28px, 4vw, 34px);
-  border-radius: clamp(24px, 5vw, 42px);
-  background: linear-gradient(160deg, rgba(20, 22, 26, 0.85), rgba(7, 8, 10, 0.7));
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-  opacity: 0.25;
-  transform: translateY(24px) scale(0.96);
-  transition: opacity 0.45s ease, transform 0.6s cubic-bezier(0.22, 0.87, 0.36, 1),
-    filter 0.6s ease;
-  font-variant-numeric: tabular-nums;
-}
-
-.metric::before {
-  content: "";
-  position: absolute;
-  inset: 12px;
-  border-radius: inherit;
-  background: radial-gradient(circle at 50% 0%, rgba(255, 0, 50, 0.16), transparent 65%);
-  opacity: 0;
-  transition: opacity 0.4s ease;
-  pointer-events: none;
-}
-
-.metric__badge {
+.speedometer__chip {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  padding: 4px 12px;
+  gap: 6px;
+  padding: 6px 12px;
   border-radius: 999px;
-  font-size: 0.75rem;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.65), rgba(255, 0, 50, 0.18));
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: rgba(22, 24, 39, 0.75);
+  font-size: 0.72rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+}
+
+.speedometer__title {
+  margin-top: 14px;
+  font-family: 'Orbitron', 'Manrope', sans-serif;
+  font-size: clamp(1.9rem, 3.4vw, 2.6rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+}
+
+.speedometer__subtitle {
+  margin-top: 12px;
+  font-size: clamp(0.85rem, 2.2vw, 1rem);
+  color: var(--text-secondary);
+  max-width: 420px;
+  margin-inline: auto;
+  line-height: 1.5;
+}
+
+.speedometer__display {
+  position: relative;
+  padding: clamp(18px, 4vw, 28px);
+  border-radius: clamp(22px, 4vw, 32px);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0.5));
+  box-shadow: inset 0 1px 4px rgba(255, 255, 255, 0.6), inset 0 -1px 10px rgba(22, 24, 39, 0.12);
+}
+
+.speedometer__display::after {
+  content: '';
+  position: absolute;
+  inset: 22px;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  pointer-events: none;
+  opacity: 0.65;
+}
+
+.speedometer__svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.speedometer__arc--progress {
+  stroke-linejoin: round;
+  opacity: 0.92;
+}
+
+.speedometer__value {
+  font-family: 'Orbitron', 'Manrope', sans-serif;
+  font-size: clamp(3.4rem, 10vw, 4.2rem);
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  fill: rgba(22, 24, 39, 0.92);
+}
+
+.speedometer__unit {
+  font-family: 'Orbitron', 'Manrope', sans-serif;
+  font-size: clamp(0.95rem, 2.4vw, 1.1rem);
+  letter-spacing: 0.58em;
+  fill: rgba(22, 24, 39, 0.52);
+  text-transform: uppercase;
+}
+
+.speedometer__status {
+  font-size: clamp(0.82rem, 2.2vw, 0.98rem);
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  fill: rgba(255, 0, 50, 0.75);
+}
+
+.speedometer__meta-label {
+  font-size: 0.65rem;
   letter-spacing: 0.32em;
   text-transform: uppercase;
-  background: rgba(255, 0, 50, 0.18);
-  border: 1px solid rgba(255, 0, 50, 0.36);
-  color: rgba(255, 255, 255, 0.78);
-  transition: transform 0.5s ease, background 0.4s ease, border-color 0.4s ease;
+  fill: rgba(22, 24, 39, 0.45);
 }
 
-.metric__title {
-  font-size: clamp(1rem, 1.6vw, 1.25rem);
-  color: var(--text-secondary);
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  letter-spacing: 0.03em;
-}
-
-.metric__hint {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  color: rgba(255, 255, 255, 0.6);
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-.metric__value {
-  font-size: clamp(2.6rem, 6vw, 3.8rem);
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  color: var(--text-primary);
-  text-shadow: 0 0 18px rgba(255, 0, 50, 0.35);
-  transition: color 0.45s ease;
-}
-
-.metric__value-number {
-  display: inline-block;
-  min-width: 5ch;
-  text-align: center;
-}
-
-.metric__unit {
-  font-size: clamp(0.95rem, 1.4vw, 1.1rem);
-  color: var(--text-tertiary);
+.speedometer__meta-value {
+  font-family: 'Orbitron', 'Manrope', sans-serif;
+  font-size: 0.98rem;
+  letter-spacing: 0.38em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  fill: rgba(22, 24, 39, 0.72);
 }
 
-.metric--active {
-  opacity: 1;
-  transform: translateY(0) scale(1.02);
-  filter: drop-shadow(0 20px 40px rgba(255, 0, 50, 0.38));
+.speedometer__ticks line {
+  transform-origin: center;
 }
 
-.metric--active::before {
-  opacity: 1;
+.speedometer__needle-core {
+  stroke: rgba(255, 255, 255, 0.8);
+  stroke-width: 1;
 }
 
-.metric--active .metric__badge {
-  transform: translateY(-4px) scale(1.08);
-  background: rgba(255, 0, 50, 0.32);
-  border-color: rgba(255, 0, 50, 0.65);
+.speedometer__needle-glow {
+  transform-origin: 50% 50%;
+  filter: blur(0.4px);
 }
 
-.metric--active .metric__title {
-  color: rgba(255, 255, 255, 0.82);
-}
-
-.metric--complete {
-  opacity: 0.92;
-  transform: translateY(0) scale(1);
-  filter: drop-shadow(0 16px 32px rgba(0, 0, 0, 0.35));
-}
-
-.metric--complete .metric__value {
-  color: #ffffff;
-}
-
-.metric--complete .metric__badge {
-  background: rgba(255, 0, 50, 0.24);
-  border-color: rgba(255, 0, 50, 0.45);
-}
-
-body.no-js .metric,
-body.no-js .metric::before,
-body.no-js .metric__badge,
-body.no-js .dial__progress-fill,
-body.no-js .dial__corner,
-body.no-js .dial__pulse {
-  animation: none;
-  transition: none;
-}
-
-body.no-js .metric {
-  opacity: 1;
-  transform: none;
-}
-
-body.no-js .dial__progress-fill {
-  opacity: 1;
-  stroke-dashoffset: 0;
-}
-
-body.no-js .dial__gear-indicator {
-  display: none;
-}
-
-@media (max-width: 840px) {
-  .metrics {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    padding: clamp(40px, 6vw, 64px) clamp(18px, 5vw, 44px) clamp(28px, 6vw, 54px);
+@media (max-width: 520px) {
+  body {
+    padding: 36px 0;
   }
 
-  .metrics::before {
-    inset: clamp(18px, 4vw, 34px) clamp(12px, 3vw, 28px);
-  }
-}
-
-@media (max-width: 580px) {
-  .metrics {
-    grid-template-columns: 1fr;
-    gap: 28px;
+  .speedometer__panel {
+    padding: 24px;
   }
 
-  .metric {
-    padding: clamp(24px, 6vw, 34px);
+  .speedometer__subtitle {
+    letter-spacing: 0.08em;
   }
-}
 
-@keyframes dial-pulse {
-  from {
-    stroke-dashoffset: 6;
-  }
-  to {
-    stroke-dashoffset: -20;
-  }
-}
-
-@keyframes dial-corner {
-  0% {
-    stroke-dashoffset: 14;
-    opacity: 0.35;
-  }
-  45% {
-    opacity: 0.85;
-  }
-  100% {
-    stroke-dashoffset: -26;
-    opacity: 0.45;
-  }
-}
-
-@keyframes dial-progress {
-  0% {
-    stroke-dashoffset: 100;
-    opacity: 0;
-  }
-  12% {
-    opacity: 1;
-  }
-  38% {
-    stroke-dashoffset: 68;
-  }
-  68% {
-    stroke-dashoffset: 28;
-  }
-  100% {
-    stroke-dashoffset: 0;
+  .speedometer__display {
+    padding: 16px;
   }
 }
 
@@ -468,10 +237,5 @@ body.no-js .dial__gear-indicator {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
-  }
-
-  body.is-ready .dial__progress-fill {
-    stroke-dashoffset: 0;
-    opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- replace the previous dashboard with a glassmorphic cyberpunk speedometer layout
- add SVG gradients, glow filters, and GSAP timelines to animate the arc, needle, and telemetry text
- introduce a Three.js neon torus background and responsive light-theme styling

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d69d6aa9fc8321b4d2057044accd97